### PR TITLE
[ENHANCEMENTS] resolveFieldsMap Helper, Wildcard Selector & Updated Args Positions

### DIFF
--- a/.github/workflows/npm-test-graphql-utils.yml
+++ b/.github/workflows/npm-test-graphql-utils.yml
@@ -10,12 +10,18 @@ name: Test package on pull request
 jobs:
   publish:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x, 15.x]
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
         with:
-          node-version: 10
-      - run: npm install
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+        working-directory: ./graphql-utils
+      - run: npm run build --if-present
         working-directory: ./graphql-utils
       - run: npm test
         working-directory: ./graphql-utils

--- a/.github/workflows/npm-test-graphql-utils.yml
+++ b/.github/workflows/npm-test-graphql-utils.yml
@@ -1,0 +1,21 @@
+name: Test package on pull request
+'on':
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10
+      - run: npm install
+        working-directory: ./graphql-utils
+      - run: npm test
+        working-directory: ./graphql-utils

--- a/graphql-utils/README.md
+++ b/graphql-utils/README.md
@@ -7,6 +7,7 @@
   - [Usage](#usage)
   - [Utilities](#utilities)
     - [`hasFields(search: string | string[], info: GraphQLResolveInfo): boolean`](#hasfieldssearch-string--string-info-graphqlresolveinfo-boolean)
+    - [`resolveFields(info: Pick<GraphQLResolveInfo, "fieldNodes" | "fragments">, deep: boolean = true, parent: string | string[] = ""): string[]`](#resolvefieldsinfo-pickgraphqlresolveinfo-fieldnodes--fragments-deep-boolean--true-parent-string--string---string)
     - [`resolveSelections(fields: (string | FieldSelections)[], info: GraphQLResolveInfo): string[]`](#resolveselectionsfields-string--fieldselections-info-graphqlresolveinfo-string)
       - [`interface FieldSelections`](#interface-fieldselections)
       - [Motivation behind `resolveSelections`](#motivation-behind-resolveselections)

--- a/graphql-utils/README.md
+++ b/graphql-utils/README.md
@@ -2,6 +2,15 @@
 
 `@jenyus-org/graphql-utils` is a collection of utilities to aid in working with GraphQL projects that have the [`graphql`](https://github.com/graphql/graphql-js) library as a base.
 
+- [graphql-utils](#graphql-utils)
+  - [Installation](#installation)
+  - [Usage](#usage)
+  - [Utilities](#utilities)
+    - [`hasFields(search: string | string[], info: GraphQLResolveInfo): boolean`](#hasfieldssearch-string--string-info-graphqlresolveinfo-boolean)
+    - [`resolveSelections(fields: (string | FieldSelections)[], info: GraphQLResolveInfo): string[]`](#resolveselectionsfields-string--fieldselections-info-graphqlresolveinfo-string)
+      - [`interface FieldSelections`](#interface-fieldselections)
+      - [Motivation behind `resolveSelections`](#motivation-behind-resolveselections)
+
 ## Installation
 
 As laid out in the main project repo, in order to install these packages the GitHub Package registry must be added to an `.npmrc` or `.yarnrc` file. View further details [here](../README.md).

--- a/graphql-utils/README.md
+++ b/graphql-utils/README.md
@@ -69,6 +69,8 @@ Alternatively, an array of fields may be used for better readability:
 const requestedPosts = hasFields(["user", "posts"], info);  // GraphQLResolveInfo provided by resolver function args
 ```
 
+### `resolveFields(info: Pick<GraphQLResolveInfo, "fieldNodes" | "fragments">, deep: boolean = true, parent: string | string[] = ""): string[]`
+
 ### `resolveSelections(fields: (string | FieldSelections)[], info: GraphQLResolveInfo): string[]`
 
 `resolveSelections` is an extension of `hasFields`, designed to aid in generating the most efficient SQL queries possible when using an ORM like [TypeORM](https://typeorm.io/).

--- a/graphql-utils/src/get-field-map.test.ts
+++ b/graphql-utils/src/get-field-map.test.ts
@@ -1,0 +1,27 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+import { getFieldMap } from "./get-field-map";
+
+describe("Getting a field map within another field map.", () => {
+  it("Must retrieve the field map under the specified parent.", () => {
+    const fieldMap = {
+      user: {
+        otherField: {
+          moreUnrelatedFields: {},
+          user: {
+            username: {},
+          },
+        },
+      },
+    };
+
+    const subFieldMap = getFieldMap(fieldMap, "user.otherField");
+
+    expect(subFieldMap).to.deep.equal({
+      moreUnrelatedFields: {},
+      user: {
+        username: {},
+      },
+    });
+  });
+});

--- a/graphql-utils/src/get-field-map.ts
+++ b/graphql-utils/src/get-field-map.ts
@@ -1,0 +1,17 @@
+import { FieldMap } from "./helpers";
+
+export const getFieldMap = (
+  fieldMap: FieldMap,
+  parent: string | string[] = []
+) => {
+  const parents = Array.isArray(parent) ? parent : parent.split(".");
+  if (!parents.length) {
+    return fieldMap;
+  }
+  for (const key of Object.keys(fieldMap)) {
+    if (key === parents[0]) {
+      parents.shift();
+      return getFieldMap(fieldMap[key], parents);
+    }
+  }
+};

--- a/graphql-utils/src/has-fields.test.ts
+++ b/graphql-utils/src/has-fields.test.ts
@@ -20,4 +20,21 @@ describe("Resolving selectors from GraphQL query fields.", () => {
 
     expect(usernameFound).to.equal(true);
   });
+
+  it("Shouldn't find fields that don't exist.", () => {
+    const info = getGraphQLResolveInfo(`{
+      user {
+        otherField {
+          moreUnrelatedFields
+          user {
+            username
+          }
+        }
+      }
+    }`);
+
+    const usernameFound = hasFields("user.dummyField", info);
+
+    expect(usernameFound).to.equal(false);
+  });
 });

--- a/graphql-utils/src/has-fields.test.ts
+++ b/graphql-utils/src/has-fields.test.ts
@@ -37,4 +37,21 @@ describe("Checking if a field exists in a given query.", () => {
 
     expect(usernameFound).to.equal(false);
   });
+
+  it("Shouldn't find fields below root-level if specified.", () => {
+    const info = getGraphQLResolveInfo(`{
+      user {
+        otherField {
+          moreUnrelatedFields
+          user {
+            username
+          }
+        }
+      }
+    }`);
+
+    const usernameFound = hasFields(info, "user.username", true);
+
+    expect(usernameFound).to.equal(false);
+  });
 });

--- a/graphql-utils/src/has-fields.test.ts
+++ b/graphql-utils/src/has-fields.test.ts
@@ -16,7 +16,7 @@ describe("Checking if a field exists in a given query.", () => {
       }
     }`);
 
-    const usernameFound = hasFields(info, "user.username");
+    const usernameFound = hasFields(info, "user.username", false);
 
     expect(usernameFound).to.equal(true);
   });

--- a/graphql-utils/src/has-fields.test.ts
+++ b/graphql-utils/src/has-fields.test.ts
@@ -3,7 +3,7 @@ import { describe } from "mocha";
 import { hasFields } from "./has-fields";
 import { getGraphQLResolveInfo } from "./helpers";
 
-describe("Resolving selectors from GraphQL query fields.", () => {
+describe("Checking if a field exists in a given query.", () => {
   it("Must work for deeply nested selectors.", () => {
     const info = getGraphQLResolveInfo(`{
       user {
@@ -16,7 +16,7 @@ describe("Resolving selectors from GraphQL query fields.", () => {
       }
     }`);
 
-    const usernameFound = hasFields("user.username", info);
+    const usernameFound = hasFields(info, "user.username");
 
     expect(usernameFound).to.equal(true);
   });
@@ -33,7 +33,7 @@ describe("Resolving selectors from GraphQL query fields.", () => {
       }
     }`);
 
-    const usernameFound = hasFields("user.dummyField", info);
+    const usernameFound = hasFields(info, "user.dummyField");
 
     expect(usernameFound).to.equal(false);
   });

--- a/graphql-utils/src/has-fields.ts
+++ b/graphql-utils/src/has-fields.ts
@@ -4,10 +4,7 @@ import {
   GraphQLResolveInfo,
   SelectionSetNode,
 } from "graphql";
-
-interface FragmentDict {
-  [key: string]: FragmentDefinitionNode;
-}
+import { FragmentDict } from "./helpers";
 
 /**
  * Searches the GraphQLResolveInfo for selectors that match the search string or array, and returns `true` if found.
@@ -28,7 +25,7 @@ interface FragmentDict {
  */
 export const hasFields = (
   search: string | string[],
-  info: GraphQLResolveInfo,
+  info: Pick<GraphQLResolveInfo, "fieldNodes" | "fragments">
 ) => {
   const { fieldNodes, fragments } = info;
   const fields = Array.isArray(search) ? search : search.split(".");
@@ -50,7 +47,7 @@ export const hasFields = (
 const hasFieldName = (
   selectionNode: FieldNode | FragmentDefinitionNode,
   search: string[],
-  fragments: FragmentDict,
+  fragments: FragmentDict
 ) => {
   if (search.length === 0) {
     return true;
@@ -88,7 +85,7 @@ const hasFieldName = (
 const hasFieldSet = (
   selectionSet: SelectionSetNode,
   search: string[],
-  fragments: FragmentDict,
+  fragments: FragmentDict
 ): boolean => {
   if (search.length === 0) {
     return true;

--- a/graphql-utils/src/has-fields.ts
+++ b/graphql-utils/src/has-fields.ts
@@ -1,11 +1,5 @@
-import {
-  FieldNode,
-  FragmentDefinitionNode,
-  GraphQLResolveInfo,
-  SelectionSetNode,
-} from "graphql";
-import { fieldMapToDot, FragmentDict } from "./helpers";
-import { resolveFieldMap } from "./resolve-field-map";
+import { GraphQLResolveInfo } from "graphql";
+import { resolveFields } from "./resolve-fields";
 
 /**
  * Searches the GraphQLResolveInfo for selectors that match the search string or array, and returns `true` if found.
@@ -30,8 +24,7 @@ export const hasFields = (
   atRoot: boolean = false
 ) => {
   const field = Array.isArray(search) ? search.join(".") : search;
-  const fieldMap = resolveFieldMap(info);
-  const fields = fieldMapToDot(fieldMap);
+  const fields = resolveFields(info);
 
   if (atRoot) {
     return fields.includes(field);

--- a/graphql-utils/src/has-fields.ts
+++ b/graphql-utils/src/has-fields.ts
@@ -4,7 +4,8 @@ import {
   GraphQLResolveInfo,
   SelectionSetNode,
 } from "graphql";
-import { FragmentDict } from "./helpers";
+import { fieldMapToDot, FragmentDict } from "./helpers";
+import { resolveFieldMap } from "./resolve-field-map";
 
 /**
  * Searches the GraphQLResolveInfo for selectors that match the search string or array, and returns `true` if found.
@@ -24,89 +25,22 @@ import { FragmentDict } from "./helpers";
  * @returns `true` if the fields were located in the query as directly nested selectors, otherwise `false`.
  */
 export const hasFields = (
+  info: Pick<GraphQLResolveInfo, "fieldNodes" | "fragments">,
   search: string | string[],
-  info: Pick<GraphQLResolveInfo, "fieldNodes" | "fragments">
+  atRoot: boolean = false
 ) => {
-  const { fieldNodes, fragments } = info;
-  const fields = Array.isArray(search) ? search : search.split(".");
+  const field = Array.isArray(search) ? search.join(".") : search;
+  const fieldMap = resolveFieldMap(info);
+  const fields = fieldMapToDot(fieldMap);
 
-  for (const fieldNode of fieldNodes) {
-    if (!fieldNode.selectionSet) {
-      continue;
-    }
-
-    const found = hasFieldName(fieldNode, fields, fragments);
-    if (found) {
-      return true;
-    }
-  }
-
-  return false;
-};
-
-const hasFieldName = (
-  selectionNode: FieldNode | FragmentDefinitionNode,
-  search: string[],
-  fragments: FragmentDict
-) => {
-  if (search.length === 0) {
-    return true;
-  }
-
-  if (selectionNode.name.value === search[0]) {
-    const newSearch = [...search];
-    newSearch.shift();
-    if (selectionNode.selectionSet) {
-      if (hasFieldSet(selectionNode.selectionSet, newSearch, fragments)) {
+  if (atRoot) {
+    return fields.includes(field);
+  } else {
+    for (const fieldDot of fields) {
+      if (fieldDot.indexOf(field) !== -1) {
         return true;
       }
     }
   }
-
-  if (selectionNode.selectionSet) {
-    for (const selection of selectionNode.selectionSet.selections) {
-      if (selection.kind === "Field") {
-        if (hasFieldName(selection, search, fragments)) {
-          return true;
-        }
-      } else if (selection.kind === "FragmentSpread") {
-        const fragment = fragments[selection.name.value];
-        if (hasFieldName(fragment, search, fragments)) {
-          return true;
-        }
-      }
-    }
-  }
-
-  return false;
-};
-
-const hasFieldSet = (
-  selectionSet: SelectionSetNode,
-  search: string[],
-  fragments: FragmentDict
-): boolean => {
-  if (search.length === 0) {
-    return true;
-  }
-
-  for (const selection of selectionSet.selections) {
-    if (selection.kind === "Field" && selection.name.value === search[0]) {
-      search.shift();
-      if (selection.selectionSet) {
-        if (hasFieldSet(selection.selectionSet, search, fragments)) {
-          return true;
-        }
-      } else if (search.length === 0) {
-        return true;
-      }
-    } else if (selection.kind === "FragmentSpread") {
-      const fragment = fragments[selection.name.value];
-      if (hasFieldSet(fragment.selectionSet, search, fragments)) {
-        return true;
-      }
-    }
-  }
-
   return false;
 };

--- a/graphql-utils/src/has-fields.ts
+++ b/graphql-utils/src/has-fields.ts
@@ -21,7 +21,7 @@ import { resolveFields } from "./resolve-fields";
 export const hasFields = (
   info: Pick<GraphQLResolveInfo, "fieldNodes" | "fragments">,
   search: string | string[],
-  atRoot: boolean = false
+  atRoot: boolean = true
 ) => {
   const field = Array.isArray(search) ? search.join(".") : search;
   const fields = resolveFields(info);

--- a/graphql-utils/src/has-fields.ts
+++ b/graphql-utils/src/has-fields.ts
@@ -54,7 +54,6 @@ const hasFieldName = (
   }
 
   if (selectionNode.name.value === search[0]) {
-    search.shift();
     const newSearch = [...search];
     newSearch.shift();
     if (selectionNode.selectionSet) {

--- a/graphql-utils/src/helpers.test.ts
+++ b/graphql-utils/src/helpers.test.ts
@@ -1,0 +1,27 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+import { FieldMap, fieldMapToDot } from "./helpers";
+
+describe("Remapping field maps to a string array.", () => {
+  it("Must work for deeply nested elements.", () => {
+    const fieldMap: FieldMap = {
+      user: {
+        tasks: {},
+        activities: {
+          task: {},
+        },
+      },
+    };
+
+    const dot = fieldMapToDot(fieldMap);
+    const expectedDots = [
+      "user",
+      "user.tasks",
+      "user.activities",
+      "user.activities.task",
+    ];
+
+    expect(dot).to.have.length(expectedDots.length);
+    expect(dot).to.have.members(expectedDots);
+  });
+});

--- a/graphql-utils/src/helpers.ts
+++ b/graphql-utils/src/helpers.ts
@@ -33,3 +33,7 @@ export function getGraphQLResolveInfo(query: string) {
 
   return (info as unknown) as GraphQLResolveInfo;
 }
+
+export interface FragmentDict {
+  [key: string]: FragmentDefinitionNode;
+}

--- a/graphql-utils/src/helpers.ts
+++ b/graphql-utils/src/helpers.ts
@@ -37,3 +37,21 @@ export function getGraphQLResolveInfo(query: string) {
 export interface FragmentDict {
   [key: string]: FragmentDefinitionNode;
 }
+
+export interface FieldMap {
+  [key: string]: FieldMap;
+}
+
+export function fieldMapToDot(
+  fieldMap: FieldMap,
+  dots: string[] = [],
+  parent: string[] = []
+) {
+  for (const key of Object.keys(fieldMap)) {
+    dots = [...dots, [...parent, key].join(".")];
+    if (fieldMap[key]) {
+      dots = fieldMapToDot(fieldMap[key], dots, [...parent, key]);
+    }
+  }
+  return dots
+}

--- a/graphql-utils/src/helpers.ts
+++ b/graphql-utils/src/helpers.ts
@@ -6,6 +6,12 @@ import {
   parse,
 } from "graphql";
 
+export interface FieldSelections {
+  field: string;
+  selector?: string;
+  selections?: (string | FieldSelections)[];
+}
+
 export function getGraphQLResolveInfo(query: string) {
   const { definitions } = parse(query);
   const operation = definitions.find(
@@ -53,5 +59,5 @@ export function fieldMapToDot(
       dots = fieldMapToDot(fieldMap[key], dots, [...parent, key]);
     }
   }
-  return dots
+  return dots;
 }

--- a/graphql-utils/src/index.ts
+++ b/graphql-utils/src/index.ts
@@ -1,3 +1,4 @@
+export { getFieldMap } from "./get-field-map";
 export { hasFields } from "./has-fields";
 export { fieldMapToDot, FieldSelections } from "./helpers";
 export { resolveFieldMap } from "./resolve-field-map";

--- a/graphql-utils/src/index.ts
+++ b/graphql-utils/src/index.ts
@@ -1,3 +1,5 @@
 export { hasFields } from "./has-fields";
-export { resolveSelections, FieldSelections } from "./resolve-selections";
+export { fieldMapToDot, FieldSelections } from "./helpers";
+export { resolveFieldMap } from "./resolve-field-map";
 export { resolveFields } from "./resolve-fields";
+export { resolveSelections } from "./resolve-selections";

--- a/graphql-utils/src/index.ts
+++ b/graphql-utils/src/index.ts
@@ -1,2 +1,3 @@
 export { hasFields } from "./has-fields";
 export { resolveSelections, FieldSelections } from "./resolve-selections";
+export { resolveFields } from "./resolve-fields";

--- a/graphql-utils/src/resolve-field-map.test.ts
+++ b/graphql-utils/src/resolve-field-map.test.ts
@@ -42,7 +42,7 @@ describe("Resolving all selected fields in a GraphQL query.", () => {
       }
     }`);
 
-    const fields = resolveFieldMap(info, "user.otherField", true);
+    const fields = resolveFieldMap(info, true, "user.otherField");
 
     expect(fields).to.deep.equal({
       moreUnrelatedFields: {},

--- a/graphql-utils/src/resolve-field-map.test.ts
+++ b/graphql-utils/src/resolve-field-map.test.ts
@@ -51,4 +51,21 @@ describe("Resolving all selected fields in a GraphQL query.", () => {
       },
     });
   });
+
+  it("Must work for a flat selection fields.", () => {
+    const info = getGraphQLResolveInfo(`{
+      user {
+        otherField {
+          moreUnrelatedFields
+          user {
+            username
+          }
+        }
+      }
+    }`);
+
+    const fields = resolveFieldMap(info, false);
+
+    expect(fields).to.deep.equal({ user: {} });
+  });
 });

--- a/graphql-utils/src/resolve-field-map.test.ts
+++ b/graphql-utils/src/resolve-field-map.test.ts
@@ -18,7 +18,7 @@ describe("Resolving all selected fields in a GraphQL query.", () => {
 
     const fields = resolveFieldMap(info);
 
-    expect(fields).to.equal({
+    expect(fields).to.deep.equal({
       user: {
         otherField: {
           moreUnrelatedFields: {},
@@ -26,6 +26,28 @@ describe("Resolving all selected fields in a GraphQL query.", () => {
             username: {},
           },
         },
+      },
+    });
+  });
+
+  it("Must work for deeply nested fields and fragments under a specified parent.", () => {
+    const info = getGraphQLResolveInfo(`{
+      user {
+        otherField {
+          moreUnrelatedFields
+          user {
+            username
+          }
+        }
+      }
+    }`);
+
+    const fields = resolveFieldMap(info, "user.otherField", true);
+
+    expect(fields).to.deep.equal({
+      moreUnrelatedFields: {},
+      user: {
+        username: {},
       },
     });
   });

--- a/graphql-utils/src/resolve-field-map.test.ts
+++ b/graphql-utils/src/resolve-field-map.test.ts
@@ -1,0 +1,32 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+import { getGraphQLResolveInfo } from "./helpers";
+import { resolveFieldMap } from "./resolve-field-map";
+
+describe("Resolving all selected fields in a GraphQL query.", () => {
+  it("Must work for deeply nested fields and fragments.", () => {
+    const info = getGraphQLResolveInfo(`{
+      user {
+        otherField {
+          moreUnrelatedFields
+          user {
+            username
+          }
+        }
+      }
+    }`);
+
+    const fields = resolveFieldMap(info);
+
+    expect(fields).to.equal({
+      user: {
+        otherField: {
+          moreUnrelatedFields: {},
+          user: {
+            username: {},
+          },
+        },
+      },
+    });
+  });
+});

--- a/graphql-utils/src/resolve-field-map.ts
+++ b/graphql-utils/src/resolve-field-map.ts
@@ -1,0 +1,86 @@
+import { GraphQLResolveInfo, SelectionSetNode } from "graphql";
+import { FieldMap } from "./helpers";
+
+export const resolveFieldMap = (
+  info: Pick<GraphQLResolveInfo, "fieldNodes" | "fragments">,
+  deep: boolean = true,
+  parent: string | string[] = []
+) => {
+  const { fieldNodes, fragments } = info;
+  let selectionSets: SelectionSetNode[] = [];
+  const fieldMap: FieldMap = {};
+  const parents = Array.isArray(parent) ? [...parent] : parent.split(".");
+
+  if (parents.length) {
+    let found = false;
+    for (const fieldNode of fieldNodes) {
+      if (fieldNode.name.value === parent[0]) {
+        parents.shift();
+        selectionSets.push(fieldNode.selectionSet);
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      return fieldMap;
+    }
+  } else {
+    for (const fieldNode of fieldNodes) {
+      selectionSets.push(fieldNode.selectionSet);
+    }
+  }
+
+  while (parents.length) {
+    const currentSelectionSets = [...selectionSets];
+    selectionSets = [];
+
+    let found = false;
+    for (const selectionSet of currentSelectionSets) {
+      if (selectionSet.selections) {
+        for (const selection of selectionSet.selections) {
+          if (selection.kind === "Field") {
+            if (selection.name.value === parents[0]) {
+              parents.shift();
+              selectionSets.push(selection.selectionSet);
+              found = true;
+              break;
+            }
+          } else if (selection.kind === "FragmentSpread") {
+            const fragment = fragments[selection.name.value];
+            if (fragment.selectionSet) {
+              selectionSets.push(fragment.selectionSet);
+              found = true;
+            }
+          }
+        }
+      }
+      if (found) {
+        break;
+      }
+    }
+    if (!found) {
+      return fieldMap;
+    }
+  }
+
+  let currentParent = [];
+  while (selectionSets.length) {
+    const currentSelectionSets = [...selectionSets];
+    selectionSets = [];
+
+    for (const selectionSet of currentSelectionSets) {
+      if (selectionSet.selections) {
+        for (const selection of selectionSet.selections) {
+          if (selection.kind === "Field") {
+            if (selection.selectionSet) {
+              selectionSets = [...selectionSets, selection.selectionSet];
+            }
+            fieldMap[selection.name.value] = {};
+          }
+        }
+      }
+    }
+  }
+
+  return fieldMap;
+};

--- a/graphql-utils/src/resolve-field-map.ts
+++ b/graphql-utils/src/resolve-field-map.ts
@@ -3,8 +3,8 @@ import { FieldMap, FragmentDict } from "./helpers";
 
 export const resolveFieldMap = (
   info: Pick<GraphQLResolveInfo, "fieldNodes" | "fragments">,
-  parent: string | string[] = [],
-  deep: boolean = true
+  deep: boolean = true,
+  parent: string | string[] = []
 ) => {
   const { fieldNodes, fragments } = info;
   const parents = Array.isArray(parent) ? [...parent] : parent.split(".");

--- a/graphql-utils/src/resolve-fields.test.ts
+++ b/graphql-utils/src/resolve-fields.test.ts
@@ -17,9 +17,16 @@ describe("Resolving selectors from GraphQL query fields.", () => {
     }`);
 
     const deepFields = resolveFields(info);
-    console.log(deepFields);
+    const expectedFields = [
+      "user",
+      "user.otherField",
+      "user.otherField.moreUnrelatedFields",
+      "user.otherField.user",
+      "user.otherField.user.username",
+    ];
 
-    expect(deepFields).to.equal(true);
+    expect(deepFields).to.have.length(expectedFields.length);
+    expect(deepFields).to.have.members(expectedFields);
   });
 
   it("Must resolve only flat fields.", () => {
@@ -35,9 +42,10 @@ describe("Resolving selectors from GraphQL query fields.", () => {
     }`);
 
     const flatFields = resolveFields(info, false);
-    console.log(flatFields);
+    const expectedFields = ["user", "user.otherField"];
 
-    expect(flatFields).to.equal(true);
+    expect(flatFields).to.have.length(expectedFields.length);
+    expect(flatFields).to.have.members(expectedFields);
   });
 
   it("Must resolve all deeply nested fields under a specified parent.", () => {
@@ -53,9 +61,15 @@ describe("Resolving selectors from GraphQL query fields.", () => {
     }`);
 
     const userFields = resolveFields(info, true, "user");
-    console.log(userFields);
+    const expectedFields = [
+      "user.otherField",
+      "user.otherField.moreUnrelatedFields",
+      "user.otherField.user",
+      "user.otherField.user.username",
+    ];
 
-    expect(userFields).to.equal(true);
+    expect(userFields).to.have.length(expectedFields.length);
+    expect(userFields).to.have.members(expectedFields);
   });
 
   it("Must resolve only flat fields under a specified parent.", () => {
@@ -71,8 +85,9 @@ describe("Resolving selectors from GraphQL query fields.", () => {
     }`);
 
     const flatUserFields = resolveFields(info, false, "user");
-    console.log(flatUserFields);
+    const expectedFields = ["user.otherField"];
 
-    expect(flatUserFields).to.equal(true);
+    expect(flatUserFields).to.have.length(expectedFields.length);
+    expect(flatUserFields).to.have.members(expectedFields);
   });
 });

--- a/graphql-utils/src/resolve-fields.test.ts
+++ b/graphql-utils/src/resolve-fields.test.ts
@@ -62,10 +62,10 @@ describe("Resolving selectors from GraphQL query fields.", () => {
 
     const userFields = resolveFields(info, true, "user");
     const expectedFields = [
-      "user.otherField",
-      "user.otherField.moreUnrelatedFields",
-      "user.otherField.user",
-      "user.otherField.user.username",
+      "otherField",
+      "otherField.moreUnrelatedFields",
+      "otherField.user",
+      "otherField.user.username",
     ];
 
     expect(userFields).to.have.length(expectedFields.length);
@@ -85,7 +85,7 @@ describe("Resolving selectors from GraphQL query fields.", () => {
     }`);
 
     const flatUserFields = resolveFields(info, false, "user");
-    const expectedFields = ["user.otherField"];
+    const expectedFields = ["otherField"];
 
     expect(flatUserFields).to.have.length(expectedFields.length);
     expect(flatUserFields).to.have.members(expectedFields);

--- a/graphql-utils/src/resolve-fields.test.ts
+++ b/graphql-utils/src/resolve-fields.test.ts
@@ -1,0 +1,78 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+import { getGraphQLResolveInfo } from "./helpers";
+import { resolveFields } from "./resolve-fields";
+
+describe("Resolving selectors from GraphQL query fields.", () => {
+  it("Must resolve all deeply nested fields.", () => {
+    const info = getGraphQLResolveInfo(`{
+      user {
+        otherField {
+          moreUnrelatedFields
+          user {
+            username
+          }
+        }
+      }
+    }`);
+
+    const deepFields = resolveFields(info);
+    console.log(deepFields);
+
+    expect(deepFields).to.equal(true);
+  });
+
+  it("Must resolve only flat fields.", () => {
+    const info = getGraphQLResolveInfo(`{
+      user {
+        otherField {
+          moreUnrelatedFields
+          user {
+            username
+          }
+        }
+      }
+    }`);
+
+    const flatFields = resolveFields(info, false);
+    console.log(flatFields);
+
+    expect(flatFields).to.equal(true);
+  });
+
+  it("Must resolve all deeply nested fields under a specified parent.", () => {
+    const info = getGraphQLResolveInfo(`{
+      user {
+        otherField {
+          moreUnrelatedFields
+          user {
+            username
+          }
+        }
+      }
+    }`);
+
+    const userFields = resolveFields(info, true, "user");
+    console.log(userFields);
+
+    expect(userFields).to.equal(true);
+  });
+
+  it("Must resolve only flat fields under a specified parent.", () => {
+    const info = getGraphQLResolveInfo(`{
+      user {
+        otherField {
+          moreUnrelatedFields
+          user {
+            username
+          }
+        }
+      }
+    }`);
+
+    const flatUserFields = resolveFields(info, false, "user");
+    console.log(flatUserFields);
+
+    expect(flatUserFields).to.equal(true);
+  });
+});

--- a/graphql-utils/src/resolve-fields.test.ts
+++ b/graphql-utils/src/resolve-fields.test.ts
@@ -41,7 +41,7 @@ describe("Resolving selectors from GraphQL query fields.", () => {
       }
     }`);
 
-    const flatFields = resolveFields(info, false, "user");
+    const flatFields = resolveFields(info, "user", false);
     const expectedFields = ["otherField"];
 
     expect(flatFields).to.have.length(expectedFields.length);
@@ -60,7 +60,7 @@ describe("Resolving selectors from GraphQL query fields.", () => {
       }
     }`);
 
-    const userFields = resolveFields(info, true, "user");
+    const userFields = resolveFields(info, "user");
     const expectedFields = [
       "otherField",
       "otherField.moreUnrelatedFields",
@@ -84,7 +84,7 @@ describe("Resolving selectors from GraphQL query fields.", () => {
       }
     }`);
 
-    const flatUserFields = resolveFields(info, false, "user");
+    const flatUserFields = resolveFields(info, "user", false);
     const expectedFields = ["otherField"];
 
     expect(flatUserFields).to.have.length(expectedFields.length);

--- a/graphql-utils/src/resolve-fields.test.ts
+++ b/graphql-utils/src/resolve-fields.test.ts
@@ -41,7 +41,7 @@ describe("Resolving selectors from GraphQL query fields.", () => {
       }
     }`);
 
-    const flatFields = resolveFields(info, "user", false);
+    const flatFields = resolveFields(info, false, "user");
     const expectedFields = ["otherField"];
 
     expect(flatFields).to.have.length(expectedFields.length);
@@ -60,7 +60,7 @@ describe("Resolving selectors from GraphQL query fields.", () => {
       }
     }`);
 
-    const userFields = resolveFields(info, "user");
+    const userFields = resolveFields(info, true, "user");
     const expectedFields = [
       "otherField",
       "otherField.moreUnrelatedFields",
@@ -84,7 +84,7 @@ describe("Resolving selectors from GraphQL query fields.", () => {
       }
     }`);
 
-    const flatUserFields = resolveFields(info, "user", false);
+    const flatUserFields = resolveFields(info, false, "user");
     const expectedFields = ["otherField"];
 
     expect(flatUserFields).to.have.length(expectedFields.length);

--- a/graphql-utils/src/resolve-fields.test.ts
+++ b/graphql-utils/src/resolve-fields.test.ts
@@ -41,8 +41,8 @@ describe("Resolving selectors from GraphQL query fields.", () => {
       }
     }`);
 
-    const flatFields = resolveFields(info, false);
-    const expectedFields = ["user", "user.otherField"];
+    const flatFields = resolveFields(info, false, "user");
+    const expectedFields = ["otherField"];
 
     expect(flatFields).to.have.length(expectedFields.length);
     expect(flatFields).to.have.members(expectedFields);

--- a/graphql-utils/src/resolve-fields.ts
+++ b/graphql-utils/src/resolve-fields.ts
@@ -18,8 +18,7 @@ export const resolveFields = (
           fieldNode,
           deep,
           parents.join("."),
-          fragments,
-          [fieldNode.name.value]
+          fragments
         );
         fields = [...fields, ...resolvedFields];
       }
@@ -62,8 +61,7 @@ const resolveFieldsFromSelectionSet = (
             fieldNode,
             deep,
             parents.join("."),
-            fragments,
-            [...fieldParent, fieldNode.name.value]
+            fragments
           );
           fields = [...fields, ...resolvedFields];
         }

--- a/graphql-utils/src/resolve-fields.ts
+++ b/graphql-utils/src/resolve-fields.ts
@@ -4,10 +4,10 @@ import { FragmentDict } from "./helpers";
 export const resolveFields = (
   info: Pick<GraphQLResolveInfo, "fieldNodes" | "fragments">,
   deep: boolean = true,
-  parent: string | string[] = "",
-  fields: string[] = []
+  parent: string | string[] = ""
 ) => {
   const { fieldNodes, fragments } = info;
+  let fields: string[] = [];
 
   if (parent) {
     const parents = Array.isArray(parent) ? parent : parent.split(".");

--- a/graphql-utils/src/resolve-fields.ts
+++ b/graphql-utils/src/resolve-fields.ts
@@ -9,6 +9,24 @@ export const resolveFields = (
 ) => {
   const { fieldNodes, fragments } = info;
 
+  if (parent) {
+    const parents = Array.isArray(parent) ? parent : parent.split(".");
+    for (const fieldNode of fieldNodes) {
+      if (fieldNode.name.value === parent) {
+        parents.shift();
+        const resolvedFields = resolveFieldsFromSelectionSet(
+          fieldNode,
+          deep,
+          parents.join("."),
+          fragments,
+          [fieldNode.name.value]
+        );
+        fields = [...fields, ...resolvedFields];
+      }
+    }
+    return fields;
+  }
+
   for (const fieldNode of fieldNodes) {
     if (!parent) {
       fields = [...fields, fieldNode.name.value];
@@ -35,12 +53,10 @@ const resolveFieldsFromSelectionSet = (
   fields: string[] = []
 ) => {
   if (parent) {
-    console.log(parent);
     const parents = Array.isArray(parent) ? parent : parent.split(".");
     for (const fieldNode of selectionNode.selectionSet.selections) {
       if (fieldNode.kind === "Field") {
         if (fieldNode.name.value === parents[0]) {
-          console.log(fieldNode);
           parents.shift();
           const resolvedFields = resolveFieldsFromSelectionSet(
             fieldNode,

--- a/graphql-utils/src/resolve-fields.ts
+++ b/graphql-utils/src/resolve-fields.ts
@@ -1,0 +1,90 @@
+import { FieldNode, FragmentDefinitionNode, GraphQLResolveInfo } from "graphql";
+import { FragmentDict } from "./helpers";
+
+export const resolveFields = (
+  info: Pick<GraphQLResolveInfo, "fieldNodes" | "fragments">,
+  deep: boolean = true,
+  parent: string | string[] = "",
+  fields: string[] = []
+) => {
+  const { fieldNodes, fragments } = info;
+
+  for (const fieldNode of fieldNodes) {
+    if (!parent) {
+      fields = [...fields, fieldNode.name.value];
+    }
+    const resolvedFields = resolveFieldsFromSelectionSet(
+      fieldNode,
+      deep,
+      parent,
+      fragments,
+      [fieldNode.name.value]
+    );
+    fields = [...fields, ...resolvedFields];
+  }
+
+  return fields;
+};
+
+const resolveFieldsFromSelectionSet = (
+  selectionNode: FieldNode | FragmentDefinitionNode,
+  deep: boolean = true,
+  parent: string | string[] = "",
+  fragments: FragmentDict,
+  fieldParent: string[] = [],
+  fields: string[] = []
+) => {
+  if (parent) {
+    console.log(parent);
+    const parents = Array.isArray(parent) ? parent : parent.split(".");
+    for (const fieldNode of selectionNode.selectionSet.selections) {
+      if (fieldNode.kind === "Field") {
+        if (fieldNode.name.value === parents[0]) {
+          console.log(fieldNode);
+          parents.shift();
+          const resolvedFields = resolveFieldsFromSelectionSet(
+            fieldNode,
+            deep,
+            parents.join("."),
+            fragments,
+            [...fieldParent, fieldNode.name.value]
+          );
+          fields = [...fields, ...resolvedFields];
+        }
+      }
+    }
+    return fields;
+  }
+
+  if (selectionNode.selectionSet) {
+    for (const selection of selectionNode.selectionSet.selections) {
+      if (selection.kind === "Field") {
+        console.log(selection.name.value);
+        const field = [...fieldParent, selection.name.value].join(".");
+        fields = [...fields, field];
+        if (deep) {
+          const resolvedFields = resolveFieldsFromSelectionSet(
+            selection,
+            deep,
+            parent,
+            fragments,
+            [...fieldParent, selection.name.value]
+          );
+          fields = [...fields, ...resolvedFields];
+        }
+      } else if (selection.kind === "FragmentSpread") {
+        const fragment = fragments[selection.name.value];
+        const resolvedFields = resolveFieldsFromSelectionSet(
+          fragment,
+          deep,
+          parent,
+          fragments,
+          [...fieldParent, selection.name.value]
+        );
+        fields = [...fields, ...resolvedFields];
+      }
+    }
+  }
+
+  return fields;
+};

--- a/graphql-utils/src/resolve-fields.ts
+++ b/graphql-utils/src/resolve-fields.ts
@@ -4,8 +4,8 @@ import { resolveFieldMap } from "./resolve-field-map";
 
 export const resolveFields = (
   info: Pick<GraphQLResolveInfo, "fieldNodes" | "fragments">,
-  deep: boolean = true,
-  parent: string | string[] = []
+  parent: string | string[] = [],
+  deep: boolean = true
 ) => {
   const fieldMap = resolveFieldMap(info, parent, deep);
   return fieldMapToDot(fieldMap);

--- a/graphql-utils/src/resolve-fields.ts
+++ b/graphql-utils/src/resolve-fields.ts
@@ -75,7 +75,6 @@ const resolveFieldsFromSelectionSet = (
   if (selectionNode.selectionSet) {
     for (const selection of selectionNode.selectionSet.selections) {
       if (selection.kind === "Field") {
-        console.log(selection.name.value);
         const field = [...fieldParent, selection.name.value].join(".");
         fields = [...fields, field];
         if (deep) {

--- a/graphql-utils/src/resolve-fields.ts
+++ b/graphql-utils/src/resolve-fields.ts
@@ -4,9 +4,9 @@ import { resolveFieldMap } from "./resolve-field-map";
 
 export const resolveFields = (
   info: Pick<GraphQLResolveInfo, "fieldNodes" | "fragments">,
-  parent: string | string[] = [],
-  deep: boolean = true
+  deep: boolean = true,
+  parent: string | string[] = []
 ) => {
-  const fieldMap = resolveFieldMap(info, parent, deep);
+  const fieldMap = resolveFieldMap(info, deep, parent);
   return fieldMapToDot(fieldMap);
 };

--- a/graphql-utils/src/resolve-fields.ts
+++ b/graphql-utils/src/resolve-fields.ts
@@ -1,103 +1,12 @@
-import { FieldNode, FragmentDefinitionNode, GraphQLResolveInfo } from "graphql";
-import { FragmentDict } from "./helpers";
+import { GraphQLResolveInfo } from "graphql";
+import { fieldMapToDot } from "./helpers";
+import { resolveFieldMap } from "./resolve-field-map";
 
 export const resolveFields = (
   info: Pick<GraphQLResolveInfo, "fieldNodes" | "fragments">,
   deep: boolean = true,
-  parent: string | string[] = ""
+  parent: string | string[] = []
 ) => {
-  const { fieldNodes, fragments } = info;
-  let fields: string[] = [];
-
-  if (parent) {
-    const parents = Array.isArray(parent) ? parent : parent.split(".");
-    for (const fieldNode of fieldNodes) {
-      if (fieldNode.name.value === parent) {
-        parents.shift();
-        const resolvedFields = resolveFieldsFromSelectionSet(
-          fieldNode,
-          deep,
-          parents.join("."),
-          fragments
-        );
-        fields = [...fields, ...resolvedFields];
-      }
-    }
-    return fields;
-  }
-
-  for (const fieldNode of fieldNodes) {
-    if (!parent) {
-      fields = [...fields, fieldNode.name.value];
-    }
-    const resolvedFields = resolveFieldsFromSelectionSet(
-      fieldNode,
-      deep,
-      parent,
-      fragments,
-      [fieldNode.name.value]
-    );
-    fields = [...fields, ...resolvedFields];
-  }
-
-  return fields;
-};
-
-const resolveFieldsFromSelectionSet = (
-  selectionNode: FieldNode | FragmentDefinitionNode,
-  deep: boolean = true,
-  parent: string | string[] = "",
-  fragments: FragmentDict,
-  fieldParent: string[] = [],
-  fields: string[] = []
-) => {
-  if (parent) {
-    const parents = Array.isArray(parent) ? parent : parent.split(".");
-    for (const fieldNode of selectionNode.selectionSet.selections) {
-      if (fieldNode.kind === "Field") {
-        if (fieldNode.name.value === parents[0]) {
-          parents.shift();
-          const resolvedFields = resolveFieldsFromSelectionSet(
-            fieldNode,
-            deep,
-            parents.join("."),
-            fragments
-          );
-          fields = [...fields, ...resolvedFields];
-        }
-      }
-    }
-    return fields;
-  }
-
-  if (selectionNode.selectionSet) {
-    for (const selection of selectionNode.selectionSet.selections) {
-      if (selection.kind === "Field") {
-        const field = [...fieldParent, selection.name.value].join(".");
-        fields = [...fields, field];
-        if (deep) {
-          const resolvedFields = resolveFieldsFromSelectionSet(
-            selection,
-            deep,
-            parent,
-            fragments,
-            [...fieldParent, selection.name.value]
-          );
-          fields = [...fields, ...resolvedFields];
-        }
-      } else if (selection.kind === "FragmentSpread") {
-        const fragment = fragments[selection.name.value];
-        const resolvedFields = resolveFieldsFromSelectionSet(
-          fragment,
-          deep,
-          parent,
-          fragments,
-          [...fieldParent, selection.name.value]
-        );
-        fields = [...fields, ...resolvedFields];
-      }
-    }
-  }
-
-  return fields;
+  const fieldMap = resolveFieldMap(info, parent, deep);
+  return fieldMapToDot(fieldMap);
 };

--- a/graphql-utils/src/resolve-selections.test.ts
+++ b/graphql-utils/src/resolve-selections.test.ts
@@ -91,7 +91,7 @@ describe("Resolving relationships from GraphQL query fields.", () => {
     }`);
 
     const relations = resolveSelections(fields, info);
-    const expectedRelations = ["projects.id", "projects.items"];
+    const expectedRelations = ["id", "items"];
 
     expect(relations).to.have.length(expectedRelations.length);
     expect(relations).to.have.members(expectedRelations);
@@ -123,13 +123,13 @@ describe("Resolving relationships from GraphQL query fields.", () => {
 
     const relations = resolveSelections(fields, info);
     const expectedRelations = [
-      "projects.id",
-      "projects.items",
-      "projects.items.tasks",
-      "projects.items.tasks.activities",
-      "projects.items.tasks.activities.id",
-      "projects.items.tasks.user",
-      "projects.items.tasks.user.id",
+      "id",
+      "items",
+      "items.tasks",
+      "items.tasks.activities",
+      "items.tasks.activities.id",
+      "items.tasks.user",
+      "items.tasks.user.id",
     ];
 
     expect(relations).to.have.length(expectedRelations.length);

--- a/graphql-utils/src/resolve-selections.test.ts
+++ b/graphql-utils/src/resolve-selections.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import { describe } from "mocha";
-import { getGraphQLResolveInfo } from "./helpers";
-import { FieldSelections, resolveSelections } from "./resolve-selections";
+import { FieldSelections, getGraphQLResolveInfo } from "./helpers";
+import { resolveSelections } from "./resolve-selections";
 
 describe("Resolving relationships from GraphQL query fields.", () => {
   it("Should resolve given relations for entered fields.", () => {

--- a/graphql-utils/src/resolve-selections.test.ts
+++ b/graphql-utils/src/resolve-selections.test.ts
@@ -65,4 +65,74 @@ describe("Resolving relationships from GraphQL query fields.", () => {
     expect(relations).to.have.length(expectedRelations.length);
     expect(relations).to.have.members(expectedRelations);
   });
+
+  it("Should resolve wildcards.", () => {
+    const fields: FieldSelections[] = [
+      {
+        field: "projects",
+        selections: ["*"],
+      },
+    ];
+
+    const info = getGraphQLResolveInfo(`{
+      projects(search: "Test") {
+        id
+        items {
+          tasks {
+            activities {
+              id
+            }
+            user {
+              id
+            }
+          }
+        }
+      }
+    }`);
+
+    const relations = resolveSelections(fields, info);
+    const expectedRelations = ["projects.id", "projects.items"];
+
+    expect(relations).to.have.length(expectedRelations.length);
+    expect(relations).to.have.members(expectedRelations);
+  });
+
+  it("Should resolve deep wildcards.", () => {
+    const fields: FieldSelections[] = [
+      {
+        field: "projects",
+        selections: ["**"],
+      },
+    ];
+
+    const info = getGraphQLResolveInfo(`{
+      projects(search: "Test") {
+        id
+        items {
+          tasks {
+            activities {
+              id
+            }
+            user {
+              id
+            }
+          }
+        }
+      }
+    }`);
+
+    const relations = resolveSelections(fields, info);
+    const expectedRelations = [
+      "projects.id",
+      "projects.items",
+      "projects.items.tasks",
+      "projects.items.tasks.activities",
+      "projects.items.tasks.activities.id",
+      "projects.items.tasks.user",
+      "projects.items.tasks.user.id",
+    ];
+
+    expect(relations).to.have.length(expectedRelations.length);
+    expect(relations).to.have.members(expectedRelations);
+  });
 });

--- a/graphql-utils/src/resolve-selections.test.ts
+++ b/graphql-utils/src/resolve-selections.test.ts
@@ -42,7 +42,7 @@ describe("Resolving relationships from GraphQL query fields.", () => {
         selections: [
           {
             field: "otherField",
-            selections: ["user.username"],
+            selections: ["user.username", "dummyField"],
           },
         ],
       },

--- a/graphql-utils/src/resolve-selections.ts
+++ b/graphql-utils/src/resolve-selections.ts
@@ -1,5 +1,4 @@
 import { GraphQLResolveInfo } from "graphql";
-import { hasFields } from "./has-fields";
 import { FieldSelections } from "./helpers";
 import { resolveFields } from "./resolve-fields";
 
@@ -10,6 +9,7 @@ export const resolveSelections = (
   parent?: string
 ) => {
   let resolvedSelections = [...selections];
+  const resolvedFields = resolveFields(info);
 
   for (const fieldSelection of fields) {
     let field: string;
@@ -35,7 +35,11 @@ export const resolveSelections = (
       field = [...parent.split("."), ...field.split(".")].join(".");
     }
 
-    if (hasFields(info, field)) {
+    const hasField = resolvedFields.reduce(
+      (hf, f) => hf || f.indexOf(field) !== -1,
+      false
+    );
+    if (hasField) {
       if (selector) {
         resolvedSelections = [...resolvedSelections, selector];
       }

--- a/graphql-utils/src/resolve-selections.ts
+++ b/graphql-utils/src/resolve-selections.ts
@@ -26,9 +26,9 @@ export const resolveSelections = (
     }
 
     if (field === "*") {
-      return [...resolvedSelections, ...resolveFields(info, parent, false)];
+      return [...resolvedSelections, ...resolveFields(info, false, parent)];
     } else if (field === "**") {
-      return [...resolvedSelections, ...resolveFields(info, parent)];
+      return [...resolvedSelections, ...resolveFields(info, true, parent)];
     }
 
     if (parent) {

--- a/graphql-utils/src/resolve-selections.ts
+++ b/graphql-utils/src/resolve-selections.ts
@@ -31,9 +31,9 @@ export const resolveSelections = (
     }
 
     if (field === "*") {
-      return [...resolvedSelections, ...resolveFields(info, false, parent)];
+      return [...resolvedSelections, ...resolveFields(info, parent, false)];
     } else if (field === "**") {
-      return [...resolvedSelections, ...resolveFields(info, true, parent)];
+      return [...resolvedSelections, ...resolveFields(info, parent)];
     }
 
     if (parent) {

--- a/graphql-utils/src/resolve-selections.ts
+++ b/graphql-utils/src/resolve-selections.ts
@@ -1,6 +1,7 @@
 import { GraphQLResolveInfo } from "graphql";
-import { FieldSelections } from "./helpers";
-import { resolveFields } from "./resolve-fields";
+import { getFieldMap } from "./get-field-map";
+import { fieldMapToDot, FieldSelections } from "./helpers";
+import { resolveFieldMap } from "./resolve-field-map";
 
 export const resolveSelections = (
   fields: (string | FieldSelections)[],
@@ -9,7 +10,8 @@ export const resolveSelections = (
   parent?: string
 ) => {
   let resolvedSelections = [...selections];
-  const resolvedFields = resolveFields(info);
+  const fieldMap = resolveFieldMap(info);
+  const resolvedFields = fieldMapToDot(fieldMap);
 
   for (const fieldSelection of fields) {
     let field: string;
@@ -26,9 +28,12 @@ export const resolveSelections = (
     }
 
     if (field === "*") {
-      return [...resolvedSelections, ...resolveFields(info, false, parent)];
+      const subFieldMap = getFieldMap(fieldMap, parent);
+      return [...resolvedSelections, ...Object.keys(subFieldMap)];
     } else if (field === "**") {
-      return [...resolvedSelections, ...resolveFields(info, true, parent)];
+      const subFieldMap = getFieldMap(fieldMap, parent);
+      const subFields = fieldMapToDot(subFieldMap);
+      return [...resolvedSelections, ...subFields];
     }
 
     if (parent) {

--- a/graphql-utils/src/resolve-selections.ts
+++ b/graphql-utils/src/resolve-selections.ts
@@ -40,7 +40,7 @@ export const resolveSelections = (
       field = [...parent.split("."), ...field.split(".")].join(".");
     }
 
-    if (hasFields(field, info)) {
+    if (hasFields(info, field)) {
       if (selector) {
         resolvedSelections = [...resolvedSelections, selector];
       }

--- a/graphql-utils/src/resolve-selections.ts
+++ b/graphql-utils/src/resolve-selections.ts
@@ -1,12 +1,7 @@
 import { GraphQLResolveInfo } from "graphql";
 import { hasFields } from "./has-fields";
+import { FieldSelections } from "./helpers";
 import { resolveFields } from "./resolve-fields";
-
-export interface FieldSelections {
-  field: string;
-  selector?: string;
-  selections?: (string | FieldSelections)[];
-}
 
 export const resolveSelections = (
   fields: (string | FieldSelections)[],

--- a/graphql-utils/src/resolve-selections.ts
+++ b/graphql-utils/src/resolve-selections.ts
@@ -1,5 +1,6 @@
 import { GraphQLResolveInfo } from "graphql";
 import { hasFields } from "./has-fields";
+import { resolveFields } from "./resolve-fields";
 
 export interface FieldSelections {
   field: string;
@@ -11,7 +12,7 @@ export const resolveSelections = (
   fields: (string | FieldSelections)[],
   info: GraphQLResolveInfo,
   selections: string[] = [],
-  parent?: string,
+  parent?: string
 ) => {
   let resolvedSelections = [...selections];
 
@@ -29,6 +30,12 @@ export const resolveSelections = (
       }
     }
 
+    if (field === "*") {
+      return [...resolvedSelections, ...resolveFields(info, false, parent)];
+    } else if (field === "**") {
+      return [...resolvedSelections, ...resolveFields(info, true, parent)];
+    }
+
     if (parent) {
       field = [...parent.split("."), ...field.split(".")].join(".");
     }
@@ -43,7 +50,7 @@ export const resolveSelections = (
           fieldSelection.selections,
           info,
           resolvedSelections,
-          field,
+          field
         );
       }
     }


### PR DESCRIPTION
# Overview

## General

 - Move `FieldSelection` interface to `helpers.ts`.

## Updates

 - Add `atRoot` argument to `hasFields` to check for field only at root-level.
 - Use `resolveFields` in `hasFields` to avoid duplicate logic.
 - Use new helper `resolveFieldMap` and `fieldMapToDot` (see below) in `resolveFields` to avoid duplicate logic.

## New Helpers

### `resolveFieldMap`

Resolves all the fields found in the given `GraphQLResolveInfo` object, and returns a nested objects with the located fields. This new helper is used as the basis for most other operations in `graphql-utils`, and also allows to be passed arguments `parent` and `deep` for more fine-grain control over the results.

### `fieldMapToDot`

Remaps nested objects such as those returned by `resolveFieldMap` to a dot-notated array, as those returned by `resolveSelections` and `resolveFields`.

## Tests

 - Add test for `hasFields` to check non-existent fields.
 - Add test for `resolveSelections` to check non-existent fields.
 - Add test for wildcards with `*` and `**` (deep) selections in `resolveSelections`.