### PR TITLE
[ENHANCEMENT] NestJS Wrapper Decorators for resolveFieldMaps and resolveFields Utilities

### DIFF
--- a/graphql-utils/README.md
+++ b/graphql-utils/README.md
@@ -12,7 +12,7 @@
     - [`FieldSelections`](#fieldselections)
   - [Utilities](#utilities)
     - [`fieldMapToDot (fieldMap: FieldMap): string[]`](#fieldmaptodot-fieldmap-fieldmap-string)
-    - [`getFieldMap (fieldMap: FieldMap, parent: string | string[] = []): FieldMap`](#getfieldmap-fieldmap-fieldmap-parent-string--string---fieldmap)
+    - [`getFieldMap (fieldMap: FieldMap, parent: string | string[]): FieldMap`](#getfieldmap-fieldmap-fieldmap-parent-string--string-fieldmap)
     - [`hasFields(info: GraphQLResolveInfo, search: string | string[], atRoot: boolean = false): boolean`](#hasfieldsinfo-graphqlresolveinfo-search-string--string-atroot-boolean--false-boolean)
     - [`resolveFieldMap(info: Pick<GraphQLResolveInfo, "fieldNodes" | "fragments">, deep: boolean = true, parent: string | string[] = ""): FieldMap`](#resolvefieldmapinfo-pickgraphqlresolveinfo-fieldnodes--fragments-deep-boolean--true-parent-string--string---fieldmap)
     - [`resolveFields(info: Pick<GraphQLResolveInfo, "fieldNodes" | "fragments">, deep: boolean = true, parent: string | string[] = ""): string[]`](#resolvefieldsinfo-pickgraphqlresolveinfo-fieldnodes--fragments-deep-boolean--true-parent-string--string---string)
@@ -94,7 +94,7 @@ console.log(dot);
 ]
 ```
 
-### `getFieldMap (fieldMap: FieldMap, parent: string | string[] = []): FieldMap`
+### `getFieldMap (fieldMap: FieldMap, parent: string | string[]): FieldMap`
 
 Given a `FieldMap` and the `parent` argument, this function will return a sub-selection of the field map. This is useful for optimization purposes if a `FieldMap` from the `GraphQLResolveInfo` is already available to retrieve selections and subselections using this helper.
 

--- a/graphql-utils/src/get-field-map.ts
+++ b/graphql-utils/src/get-field-map.ts
@@ -1,9 +1,6 @@
 import { FieldMap } from "./helpers";
 
-export const getFieldMap = (
-  fieldMap: FieldMap,
-  parent: string | string[] = []
-) => {
+export const getFieldMap = (fieldMap: FieldMap, parent: string | string[]) => {
   const parents = Array.isArray(parent) ? parent : parent.split(".");
   if (!parents.length) {
     return fieldMap;

--- a/graphql-utils/src/index.ts
+++ b/graphql-utils/src/index.ts
@@ -1,6 +1,6 @@
 export { getFieldMap } from "./get-field-map";
 export { hasFields } from "./has-fields";
-export { fieldMapToDot, FieldSelections } from "./helpers";
+export { fieldMapToDot, FieldSelections, FieldMap } from "./helpers";
 export { resolveFieldMap } from "./resolve-field-map";
 export { resolveFields } from "./resolve-fields";
 export { resolveSelections } from "./resolve-selections";

--- a/nestjs-graphql-utils/README.md
+++ b/nestjs-graphql-utils/README.md
@@ -28,6 +28,64 @@ All the utilities provided by `@jenyus-org/nestjs-graphql-utils` are exported di
 
 ## Decorators
 
+### `@FieldMap(deep: boolean = true, parent: string | string[] = []): FieldMap`
+
+This decorator wraps the `resolveFieldMap` utility from `graphql-utils` including the direct passing of arguments fed to the decorator. It returns a raw `FieldMap` instance which takes on the form of nested objects, where the keys represent the selected fields from the `GraphQLResolveInfo`. Keys with no sub-selections are assigned an empty object as their value.
+
+**Example usage in a GraphQL resolver:**
+
+```ts
+@Query(() => UserObject, { nullable: true })
+async user(
+  @FieldMap() fieldMap: FieldMap,
+) {
+  console.log(fieldMap);
+}
+```
+
+Given the following query:
+
+```gql
+{
+  user {
+    username
+  }
+}
+```
+
+The returned `FieldMap` will be:
+
+```ts
+{
+  user: {
+    username: {},
+  }
+}
+```
+
+### `@Fields(deep: boolean = true, parent: string | string[] = []): string[]`
+
+`@Fields` is a wrapper over the `resolveFields` utility from `graphql-utils`, which itself is a light wrapper of the `resolveFieldMaps` utility that remaps the `FieldMap` return by the function with `fieldMapToDot`.
+
+Instead of returning a `FieldMap` result, it returns a `string[]` which are a list of all the requested fields in dot notation.
+
+**Example usage in a GraphQL resolver:**
+
+```ts
+@Query(() => UserObject, { nullable: true })
+async user(
+  @Fields() fields: string[],
+) {
+  console.log(fields);
+}
+```
+
+Using the same query as above, the output would be the following:
+
+```ts
+["user", "user.username"]
+```
+
 ### `@HasFields(...fields: (string | string[])[]): boolean`
 
 `@HasFields()` uses the received `GraphQLResolveInfo` from the incoming request, to run [`hasFields`](../graphql-utils/../README.md) for every argument passed. Just like `hasFields` it supports array syntax and dot notation, and uses AND bitwise operations ensuring that every field passed resolves to `true`.

--- a/nestjs-graphql-utils/package-lock.json
+++ b/nestjs-graphql-utils/package-lock.json
@@ -202,9 +202,9 @@
       }
     },
     "@jenyus-org/graphql-utils": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@jenyus-org/graphql-utils/-/graphql-utils-1.1.0.tgz",
-      "integrity": "sha512-H33G35w0R2ANBRCgPOgLTDsN5MxNLHANwOXZf9q25+l+ra0qrrZbCGX2adAcnFF0y0bvGTqZvzpupqLZnseCDg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@jenyus-org/graphql-utils/-/graphql-utils-1.2.0.tgz",
+      "integrity": "sha512-wCwcWWPun3nz06REsxspdLCLtsgL+V3QJ6Da+gTYSG6yjXeIqpTHLINpAqwqTbhCaGgOjnO39wc3btxMv5GMXg==",
       "requires": {
         "graphql": "^15.5.0"
       }

--- a/nestjs-graphql-utils/package.json
+++ b/nestjs-graphql-utils/package.json
@@ -17,7 +17,7 @@
   "private": false,
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@jenyus-org/graphql-utils": "^1.0.0",
+    "@jenyus-org/graphql-utils": "^1.2.0",
     "@nestjs/common": "^7.6.12",
     "@nestjs/core": "^7.6.12",
     "@nestjs/graphql": "^7.9.8",

--- a/nestjs-graphql-utils/src/field-map.decorator.test.ts
+++ b/nestjs-graphql-utils/src/field-map.decorator.test.ts
@@ -1,0 +1,34 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+import { FieldMap } from "./field-map.decorator";
+import { getGqlExecutionContext, getParamDecoratorFactory } from "./helpers";
+
+describe("Retrieving a FieldMap from the GraphQLResolveInfo.", () => {
+  it("Must resolve all fields.", () => {
+    const ctx = getGqlExecutionContext(`{
+      user {
+        username
+        firstName
+        lastName
+      }
+    }`);
+
+    const fieldMap = getParamDecoratorFactory(FieldMap);
+
+    const resolvedFieldMap = fieldMap(
+      {
+        deep: true,
+        parents: [],
+      },
+      ctx
+    );
+
+    expect(resolvedFieldMap).to.deep.equal({
+      user: {
+        username: {},
+        firstName: {},
+        lastName: {},
+      },
+    });
+  });
+});

--- a/nestjs-graphql-utils/src/field-map.decorator.ts
+++ b/nestjs-graphql-utils/src/field-map.decorator.ts
@@ -1,0 +1,22 @@
+import { resolveFieldMap } from "@jenyus-org/graphql-utils";
+import { FieldMap as IFieldMap } from "@jenyus-org/graphql-utils/dist/helpers";
+import { createParamDecorator, ExecutionContext } from "@nestjs/common";
+import { GqlExecutionContext } from "@nestjs/graphql";
+
+export const FieldMap = (
+  deep: boolean = true,
+  parent: string | string[] = []
+) => {
+  return createParamDecorator<
+    {
+      deep: boolean;
+      parent: string | string[];
+    },
+    ExecutionContext,
+    IFieldMap
+  >(({ deep, parent }, context) => {
+    const ctx = GqlExecutionContext.create(context);
+    const info = ctx.getInfo();
+    return resolveFieldMap(info, deep, parent);
+  })({ deep, parent });
+};

--- a/nestjs-graphql-utils/src/fields.decorator.test.ts
+++ b/nestjs-graphql-utils/src/fields.decorator.test.ts
@@ -1,0 +1,35 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+import { Fields } from "./fields.decorator";
+import { getGqlExecutionContext, getParamDecoratorFactory } from "./helpers";
+
+describe("Retrieving fields from the GraphQLResolveInfo in dot notation form.", () => {
+  it("Must resolve all fields.", () => {
+    const ctx = getGqlExecutionContext(`{
+      user {
+        username
+        firstName
+        lastName
+      }
+    }`);
+
+    const fields = getParamDecoratorFactory(Fields);
+
+    const resolvedFields = fields(
+      {
+        deep: true,
+        parents: [],
+      },
+      ctx
+    );
+    const expectedFields = [
+      "user",
+      "user.username",
+      "user.firstName",
+      "user.lastName",
+    ];
+
+    expect(resolvedFields).to.have.length(expectedFields.length);
+    expect(resolvedFields).to.have.members(expectedFields);
+  });
+});

--- a/nestjs-graphql-utils/src/fields.decorator.ts
+++ b/nestjs-graphql-utils/src/fields.decorator.ts
@@ -1,0 +1,21 @@
+import { resolveFields } from "@jenyus-org/graphql-utils";
+import { createParamDecorator, ExecutionContext } from "@nestjs/common";
+import { GqlExecutionContext } from "@nestjs/graphql";
+
+export const Fields = (
+  deep: boolean = true,
+  parent: string | string[] = []
+) => {
+  return createParamDecorator<
+    {
+      deep: boolean;
+      parent: string | string[];
+    },
+    ExecutionContext,
+    string[]
+  >(({ deep, parent }, context) => {
+    const ctx = GqlExecutionContext.create(context);
+    const info = ctx.getInfo();
+    return resolveFields(info, deep, parent);
+  })({ deep, parent });
+};

--- a/nestjs-graphql-utils/src/has-fields.decorator.test.ts
+++ b/nestjs-graphql-utils/src/has-fields.decorator.test.ts
@@ -3,8 +3,8 @@ import { describe } from "mocha";
 import { HasFields } from "./has-fields.decorator";
 import { getGqlExecutionContext, getParamDecoratorFactory } from "./helpers";
 
-describe("Resolving selectors from GraphQL query fields.", () => {
-  it("Must work for deeply nested selectors.", () => {
+describe("Checking if a field exists.", () => {
+  it("Must work for deeply nested fields.", () => {
     const ctx = getGqlExecutionContext(`{
       user {
         username

--- a/nestjs-graphql-utils/src/has-fields.decorator.ts
+++ b/nestjs-graphql-utils/src/has-fields.decorator.ts
@@ -8,7 +8,7 @@ export const HasFields = (...fields: (string | string[])[]) => {
       const ctx = GqlExecutionContext.create(context);
       const info = ctx.getInfo();
       for (const field of search) {
-        if (!hasFields(field, info)) {
+        if (!hasFields(info, field)) {
           return false;
         }
       }


### PR DESCRIPTION
# Overview

Add NestJS wrappers for newly added utilities to `graphql-utilities` where the `GraphQLResolveInfo` can be implied by the execution context.

Wrappers added:
 - `@FieldMap()`: Wrapper of `resolveFieldMap()`
 - `@Fields()`: Wrapper of `resolveFields()`

These decorators take the same arguments as their underlying utilities, without any remapping taking effect.

Other changes:
 - Updated typing of `getFieldMap()` as `parent` must be specified.
 - Fixed usage of `graphql-utils` methods in `nestjs-graphql-utils` due to updated parameter order.
 - Export `FieldMap` from `graphql-utils`.