### PR TITLE
[ENHANCEMENT] getFieldNode Utility

### DIFF
--- a/graphql-utils/README.md
+++ b/graphql-utils/README.md
@@ -13,6 +13,7 @@
   - [Utilities](#utilities)
     - [`fieldMapToDot (fieldMap: FieldMap): string[]`](#fieldmaptodot-fieldmap-fieldmap-string)
     - [`getFieldMap (fieldMap: FieldMap, parent: string | string[]): FieldMap`](#getfieldmap-fieldmap-fieldmap-parent-string--string-fieldmap)
+    - [`getFieldNode (info: Pick<GraphQLResolveInfo, "fieldNodes" | "fragments">, path: string | string[] = []): FieldNode | undefined`](#getfieldnode-info-pickgraphqlresolveinfo-fieldnodes--fragments-path-string--string---fieldnode--undefined)
     - [`hasFields(info: GraphQLResolveInfo, search: string | string[], atRoot: boolean = false): boolean`](#hasfieldsinfo-graphqlresolveinfo-search-string--string-atroot-boolean--false-boolean)
     - [`resolveFieldMap(info: Pick<GraphQLResolveInfo, "fieldNodes" | "fragments">, deep: boolean = true, parent: string | string[] = ""): FieldMap`](#resolvefieldmapinfo-pickgraphqlresolveinfo-fieldnodes--fragments-deep-boolean--true-parent-string--string---fieldmap)
     - [`resolveFields(info: Pick<GraphQLResolveInfo, "fieldNodes" | "fragments">, deep: boolean = true, parent: string | string[] = ""): string[]`](#resolvefieldsinfo-pickgraphqlresolveinfo-fieldnodes--fragments-deep-boolean--true-parent-string--string---string)
@@ -65,6 +66,8 @@ interface FieldSelections {
 
 ### `fieldMapToDot (fieldMap: FieldMap): string[]`
 
+**New in v1.2.0**
+
 Given a `FieldMap`, this utility will return the dot notations of the field selections.
 
 **Example:**
@@ -96,7 +99,17 @@ console.log(dot);
 
 ### `getFieldMap (fieldMap: FieldMap, parent: string | string[]): FieldMap`
 
+**New in v1.1.0**
+
 Given a `FieldMap` and the `parent` argument, this function will return a sub-selection of the field map. This is useful for optimization purposes if a `FieldMap` from the `GraphQLResolveInfo` is already available to retrieve selections and subselections using this helper.
+
+### `getFieldNode (info: Pick<GraphQLResolveInfo, "fieldNodes" | "fragments">, path: string | string[] = []): FieldNode | undefined`
+
+**New in v1.3.0**
+
+Given the `GraphQLResolveInfo`, `getFieldNode` will retrieve the `FieldNode` at a specified path. The path may be specified with dot notation or as an array of fields. If no `FieldNode` was found, `undefined` will be returned.
+
+**Note:** This function returns a raw `FieldNode` and doesn't do any remapping of fields or fragments. It's meant for internal use or more advanced users looking to hook into the GraphQL system directly.
 
 ### `hasFields(info: GraphQLResolveInfo, search: string | string[], atRoot: boolean = false): boolean`
 
@@ -133,11 +146,15 @@ The `atRoot` parameter allows users to specify whether the utility should only c
 
 ### `resolveFieldMap(info: Pick<GraphQLResolveInfo, "fieldNodes" | "fragments">, deep: boolean = true, parent: string | string[] = ""): FieldMap`
 
+**New in v1.1.0**
+
 Given the `GraphQLResolveInfo`, this helper will return a `FieldMap` with all the nested selectors of the query.
 
 The `deep` argument allows to be specified whether it should only search through a single layer of field selections, or go further down the tree. It is evaluated after the `parent` has been found, meaning that this allows you to make targeted searches for e.g. `user.posts` field selections or the sorts.
 
 ### `resolveFields(info: Pick<GraphQLResolveInfo, "fieldNodes" | "fragments">, deep: boolean = true, parent: string | string[] = ""): string[]`
+
+**New in v1.1.0**
 
 Similar to `resolveFieldMap`, `resolveFields` will return either flat or deep field selections made in the query, under the specified `parent` which may be passed as a dot-notated string or array of fields. The return value will be the dot-notated field selections which are returned by the `fieldMapToDot` helper.
 

--- a/graphql-utils/src/get-field-map.test.ts
+++ b/graphql-utils/src/get-field-map.test.ts
@@ -2,8 +2,8 @@ import { expect } from "chai";
 import { describe } from "mocha";
 import { getFieldMap } from "./get-field-map";
 
-describe("Getting a field map within another field map.", () => {
-  it("Must retrieve the field map under the specified parent.", () => {
+describe("Getting a field map within another field map", () => {
+  it("Must retrieve the field map under the specified parent", () => {
     const fieldMap = {
       user: {
         otherField: {

--- a/graphql-utils/src/get-field-node.test.ts
+++ b/graphql-utils/src/get-field-node.test.ts
@@ -5,7 +5,7 @@ import { getFieldNode } from "./get-field-node";
 import { getGraphQLResolveInfo } from "./helpers";
 
 describe("Retrieving field nodes from a selected path.", () => {
-  it("Must with multiple similar paths.", () => {
+  it("Must work with multiple similar paths", () => {
     const info = getGraphQLResolveInfo(`{
       user {
         profile {
@@ -21,9 +21,29 @@ describe("Retrieving field nodes from a selected path.", () => {
 
     const fieldNode = getFieldNode(info, "user.profile.img");
 
+    expect(fieldNode.kind).to.equal("Field");
+    expect(fieldNode.selectionSet.kind).to.equal("SelectionSet");
     expect(fieldNode.selectionSet.selections[0].kind).to.equal("Field");
     expect(
       (fieldNode.selectionSet.selections[0] as FieldNode).name.value
     ).to.equal("src");
+  });
+
+  it("Must not skip paths", () => {
+    const info = getGraphQLResolveInfo(`{
+      user {
+        profile {
+          imgs {
+            icon {
+              src
+            }
+          }
+        }
+      }
+    }`);
+
+    const fieldNode = getFieldNode(info, "user.profile.icon");
+
+    expect(fieldNode).to.be.undefined;
   });
 });

--- a/graphql-utils/src/get-field-node.test.ts
+++ b/graphql-utils/src/get-field-node.test.ts
@@ -1,0 +1,29 @@
+import { expect } from "chai";
+import { FieldNode } from "graphql";
+import { describe } from "mocha";
+import { getFieldNode } from "./get-field-node";
+import { getGraphQLResolveInfo } from "./helpers";
+
+describe("Retrieving field nodes from a selected path.", () => {
+  it("Must with multiple similar paths.", () => {
+    const info = getGraphQLResolveInfo(`{
+      user {
+        profile {
+          img {
+            src
+          }
+        }
+        profile {
+          slug
+        }
+      }
+    }`);
+
+    const fieldNode = getFieldNode(info, "user.profile.img");
+
+    expect(fieldNode.selectionSet.selections[0].kind).to.equal("Field");
+    expect(
+      (fieldNode.selectionSet.selections[0] as FieldNode).name.value
+    ).to.equal("src");
+  });
+});

--- a/graphql-utils/src/get-field-node.test.ts
+++ b/graphql-utils/src/get-field-node.test.ts
@@ -9,12 +9,12 @@ describe("Retrieving field nodes from a selected path.", () => {
     const info = getGraphQLResolveInfo(`{
       user {
         profile {
+          slug
+        }
+        profile {
           img {
             src
           }
-        }
-        profile {
-          slug
         }
       }
     }`);

--- a/graphql-utils/src/get-field-node.test.ts
+++ b/graphql-utils/src/get-field-node.test.ts
@@ -4,7 +4,7 @@ import { describe } from "mocha";
 import { getFieldNode } from "./get-field-node";
 import { getGraphQLResolveInfo } from "./helpers";
 
-describe("Retrieving field nodes from a selected path.", () => {
+describe("Retrieving field nodes from a selected path", () => {
   it("Must work with multiple similar paths", () => {
     const info = getGraphQLResolveInfo(`{
       user {

--- a/graphql-utils/src/get-field-node.ts
+++ b/graphql-utils/src/get-field-node.ts
@@ -1,0 +1,41 @@
+import { FieldNode, GraphQLResolveInfo, SelectionNode } from "graphql";
+
+export const getFieldNode = (
+  info: Pick<GraphQLResolveInfo, "fieldNodes" | "fragments">,
+  path: string | string[] = []
+): FieldNode | undefined => {
+  const { fieldNodes, fragments } = info;
+  const fields = Array.isArray(path) ? [...path] : path.split(".");
+
+  let selectionNodes: SelectionNode[] = [...fieldNodes];
+  while (selectionNodes.length) {
+    const currentNodes = [...selectionNodes];
+    selectionNodes = [];
+    for (const selectionNode of currentNodes) {
+      let found = false;
+      if (selectionNode.kind === "Field") {
+        if (selectionNode.name.value === fields[0]) {
+          if (!found) {
+            fields.shift();
+            found = true;
+          }
+          if (!fields.length) {
+            return selectionNode;
+          }
+          if (selectionNode.selectionSet) {
+            selectionNodes = [
+              ...selectionNodes,
+              ...selectionNode.selectionSet.selections,
+            ];
+          }
+        }
+      } else if (selectionNode.kind === "FragmentSpread") {
+        const fragment = fragments[selectionNode.name.value];
+        selectionNodes = [
+          ...selectionNodes,
+          ...fragment.selectionSet.selections,
+        ];
+      }
+    }
+  }
+};

--- a/graphql-utils/src/get-field-node.ts
+++ b/graphql-utils/src/get-field-node.ts
@@ -11,14 +11,13 @@ export const getFieldNode = (
   while (selectionNodes.length) {
     const currentNodes = [...selectionNodes];
     selectionNodes = [];
+
+    let field = fields[0];
+    fields.shift();
+    
     for (const selectionNode of currentNodes) {
-      let found = false;
       if (selectionNode.kind === "Field") {
-        if (selectionNode.name.value === fields[0]) {
-          if (!found) {
-            fields.shift();
-            found = true;
-          }
+        if (selectionNode.name.value === field) {
           if (!fields.length) {
             return selectionNode;
           }

--- a/graphql-utils/src/has-fields.test.ts
+++ b/graphql-utils/src/has-fields.test.ts
@@ -3,8 +3,8 @@ import { describe } from "mocha";
 import { hasFields } from "./has-fields";
 import { getGraphQLResolveInfo } from "./helpers";
 
-describe("Checking if a field exists in a given query.", () => {
-  it("Must work for deeply nested selectors.", () => {
+describe("Checking if a field exists in a given query", () => {
+  it("Must work for deeply nested selectors", () => {
     const info = getGraphQLResolveInfo(`{
       user {
         otherField {
@@ -21,7 +21,7 @@ describe("Checking if a field exists in a given query.", () => {
     expect(usernameFound).to.equal(true);
   });
 
-  it("Shouldn't find fields that don't exist.", () => {
+  it("Shouldn't find fields that don't exist", () => {
     const info = getGraphQLResolveInfo(`{
       user {
         otherField {
@@ -38,7 +38,7 @@ describe("Checking if a field exists in a given query.", () => {
     expect(usernameFound).to.equal(false);
   });
 
-  it("Shouldn't find fields below root-level if specified.", () => {
+  it("Shouldn't find fields below root-level if specified", () => {
     const info = getGraphQLResolveInfo(`{
       user {
         otherField {

--- a/graphql-utils/src/helpers.test.ts
+++ b/graphql-utils/src/helpers.test.ts
@@ -2,8 +2,8 @@ import { expect } from "chai";
 import { describe } from "mocha";
 import { FieldMap, fieldMapToDot } from "./helpers";
 
-describe("Remapping field maps to a string array.", () => {
-  it("Must work for deeply nested elements.", () => {
+describe("Remapping field maps to a string array", () => {
+  it("Must work for deeply nested elements", () => {
     const fieldMap: FieldMap = {
       user: {
         tasks: {},

--- a/graphql-utils/src/index.ts
+++ b/graphql-utils/src/index.ts
@@ -4,3 +4,4 @@ export { fieldMapToDot, FieldSelections, FieldMap } from "./helpers";
 export { resolveFieldMap } from "./resolve-field-map";
 export { resolveFields } from "./resolve-fields";
 export { resolveSelections } from "./resolve-selections";
+export { getFieldNode } from "./get-field-node";

--- a/graphql-utils/src/index.ts
+++ b/graphql-utils/src/index.ts
@@ -1,7 +1,7 @@
 export { getFieldMap } from "./get-field-map";
+export { getFieldNode } from "./get-field-node";
 export { hasFields } from "./has-fields";
-export { fieldMapToDot, FieldSelections, FieldMap } from "./helpers";
+export { FieldMap, fieldMapToDot, FieldSelections } from "./helpers";
 export { resolveFieldMap } from "./resolve-field-map";
 export { resolveFields } from "./resolve-fields";
 export { resolveSelections } from "./resolve-selections";
-export { getFieldNode } from "./get-field-node";

--- a/graphql-utils/src/resolve-field-map.test.ts
+++ b/graphql-utils/src/resolve-field-map.test.ts
@@ -3,8 +3,8 @@ import { describe } from "mocha";
 import { getGraphQLResolveInfo } from "./helpers";
 import { resolveFieldMap } from "./resolve-field-map";
 
-describe("Resolving all selected fields in a GraphQL query.", () => {
-  it("Must work for deeply nested fields and fragments.", () => {
+describe("Resolving all selected fields in a GraphQL query", () => {
+  it("Must work for deeply nested fields and fragments", () => {
     const info = getGraphQLResolveInfo(`{
       user {
         otherField {
@@ -30,7 +30,7 @@ describe("Resolving all selected fields in a GraphQL query.", () => {
     });
   });
 
-  it("Must work for deeply nested fields and fragments under a specified parent.", () => {
+  it("Must work for deeply nested fields and fragments under a specified parent", () => {
     const info = getGraphQLResolveInfo(`{
       user {
         otherField {
@@ -52,7 +52,7 @@ describe("Resolving all selected fields in a GraphQL query.", () => {
     });
   });
 
-  it("Must work for a flat selection fields.", () => {
+  it("Must work for a flat selection fields", () => {
     const info = getGraphQLResolveInfo(`{
       user {
         otherField {

--- a/graphql-utils/src/resolve-fields.test.ts
+++ b/graphql-utils/src/resolve-fields.test.ts
@@ -3,8 +3,8 @@ import { describe } from "mocha";
 import { getGraphQLResolveInfo } from "./helpers";
 import { resolveFields } from "./resolve-fields";
 
-describe("Resolving selectors from GraphQL query fields.", () => {
-  it("Must resolve all deeply nested fields.", () => {
+describe("Resolving selectors from GraphQL query fields", () => {
+  it("Must resolve all deeply nested fields", () => {
     const info = getGraphQLResolveInfo(`{
       user {
         otherField {
@@ -29,7 +29,7 @@ describe("Resolving selectors from GraphQL query fields.", () => {
     expect(deepFields).to.have.members(expectedFields);
   });
 
-  it("Must resolve only flat fields.", () => {
+  it("Must resolve only flat fields", () => {
     const info = getGraphQLResolveInfo(`{
       user {
         otherField {
@@ -48,7 +48,7 @@ describe("Resolving selectors from GraphQL query fields.", () => {
     expect(flatFields).to.have.members(expectedFields);
   });
 
-  it("Must resolve all deeply nested fields under a specified parent.", () => {
+  it("Must resolve all deeply nested fields under a specified parent", () => {
     const info = getGraphQLResolveInfo(`{
       user {
         otherField {
@@ -72,7 +72,7 @@ describe("Resolving selectors from GraphQL query fields.", () => {
     expect(userFields).to.have.members(expectedFields);
   });
 
-  it("Must resolve only flat fields under a specified parent.", () => {
+  it("Must resolve only flat fields under a specified parent", () => {
     const info = getGraphQLResolveInfo(`{
       user {
         otherField {

--- a/graphql-utils/src/resolve-selections.test.ts
+++ b/graphql-utils/src/resolve-selections.test.ts
@@ -3,8 +3,8 @@ import { describe } from "mocha";
 import { FieldSelections, getGraphQLResolveInfo } from "./helpers";
 import { resolveSelections } from "./resolve-selections";
 
-describe("Resolving relationships from GraphQL query fields.", () => {
-  it("Should resolve given relations for entered fields.", () => {
+describe("Resolving relationships from GraphQL query fields", () => {
+  it("Should resolve given relations for entered fields", () => {
     const fields: FieldSelections[] = [
       {
         field: "items",
@@ -35,7 +35,7 @@ describe("Resolving relationships from GraphQL query fields.", () => {
     expect(relations).to.have.members(expectedRelations);
   });
 
-  it("Must work for deeply nested selectors.", () => {
+  it("Must work for deeply nested selectors", () => {
     const fields: FieldSelections[] = [
       {
         field: "user",
@@ -66,7 +66,7 @@ describe("Resolving relationships from GraphQL query fields.", () => {
     expect(relations).to.have.members(expectedRelations);
   });
 
-  it("Should resolve wildcards.", () => {
+  it("Should resolve wildcards", () => {
     const fields: FieldSelections[] = [
       {
         field: "projects",
@@ -97,7 +97,7 @@ describe("Resolving relationships from GraphQL query fields.", () => {
     expect(relations).to.have.members(expectedRelations);
   });
 
-  it("Should resolve deep wildcards.", () => {
+  it("Should resolve deep wildcards", () => {
     const fields: FieldSelections[] = [
       {
         field: "projects",

--- a/nestjs-graphql-utils/src/field-map.decorator.test.ts
+++ b/nestjs-graphql-utils/src/field-map.decorator.test.ts
@@ -3,8 +3,8 @@ import { describe } from "mocha";
 import { FieldMap } from "./field-map.decorator";
 import { getGqlExecutionContext, getParamDecoratorFactory } from "./helpers";
 
-describe("Retrieving a FieldMap from the GraphQLResolveInfo.", () => {
-  it("Must resolve all fields.", () => {
+describe("Retrieving a FieldMap from the GraphQLResolveInfo", () => {
+  it("Must resolve all fields", () => {
     const ctx = getGqlExecutionContext(`{
       user {
         username

--- a/nestjs-graphql-utils/src/fields.decorator.test.ts
+++ b/nestjs-graphql-utils/src/fields.decorator.test.ts
@@ -3,8 +3,8 @@ import { describe } from "mocha";
 import { Fields } from "./fields.decorator";
 import { getGqlExecutionContext, getParamDecoratorFactory } from "./helpers";
 
-describe("Retrieving fields from the GraphQLResolveInfo in dot notation form.", () => {
-  it("Must resolve all fields.", () => {
+describe("Retrieving fields from the GraphQLResolveInfo in dot notation form", () => {
+  it("Must resolve all fields", () => {
     const ctx = getGqlExecutionContext(`{
       user {
         username

--- a/nestjs-graphql-utils/src/has-fields.decorator.test.ts
+++ b/nestjs-graphql-utils/src/has-fields.decorator.test.ts
@@ -3,8 +3,8 @@ import { describe } from "mocha";
 import { HasFields } from "./has-fields.decorator";
 import { getGqlExecutionContext, getParamDecoratorFactory } from "./helpers";
 
-describe("Checking if a field exists.", () => {
-  it("Must work for deeply nested fields.", () => {
+describe("Checking if a field exists", () => {
+  it("Must work for deeply nested fields", () => {
     const ctx = getGqlExecutionContext(`{
       user {
         username

--- a/nestjs-graphql-utils/src/selections.decorator.test.ts
+++ b/nestjs-graphql-utils/src/selections.decorator.test.ts
@@ -4,8 +4,8 @@ import { describe } from "mocha";
 import { getGqlExecutionContext, getParamDecoratorFactory } from "./helpers";
 import { Selections } from "./selections.decorator";
 
-describe("Resolving selectors from GraphQL query fields.", () => {
-  it("Must resolve fields with the parent prepended to the selector.", () => {
+describe("Resolving selectors from GraphQL query fields", () => {
+  it("Must resolve fields with the parent prepended to the selector", () => {
     const ctx = getGqlExecutionContext(`{
       user {
         username
@@ -34,7 +34,7 @@ describe("Resolving selectors from GraphQL query fields.", () => {
     expect(resolvedSelections).to.have.members(expectedSelections);
   });
 
-  it("Must resolve fields using traditional resolveSelections args.", () => {
+  it("Must resolve fields using traditional resolveSelections args", () => {
     const fieldSelections: FieldSelections[] = [
       {
         field: "user",


### PR DESCRIPTION
# Overview

 - Add `getFieldNode()` utility with tests.
 - Use `getFieldNode()` in `resolveFieldMap()` when `parent` is specified.
 - Update docs.

## `getFieldNode`

Added a new utility which returns the raw `FieldNode` for a given path, and includes fragments in the search. Includes tests and exported by `graphql-utils`.