### PR TITLE
[ENHANCEMENT] @FieldNodeAt Param Decorator

### DIFF
--- a/nestjs-graphql-utils/README.md
+++ b/nestjs-graphql-utils/README.md
@@ -4,6 +4,15 @@
 
 `@jenyus-org/nestjs-graphql-utils` is a collection of utilities and decorators built on top of [`@jenyus-org/graphql-utils`](../graphql-utils/) to encourage the stateless nature of NestJS GraphQL resolvers and simplify the usage of helpers.
 
+- [nestjs-graphql-utils](#nestjs-graphql-utils)
+  - [Installation](#installation)
+  - [Usage](#usage)
+  - [Decorators](#decorators)
+    - [`@FieldMap(deep: boolean = true, parent: string | string[] = []): FieldMap`](#fieldmapdeep-boolean--true-parent-string--string---fieldmap)
+    - [`@Fields(deep: boolean = true, parent: string | string[] = []): string[]`](#fieldsdeep-boolean--true-parent-string--string---string)
+    - [`@HasFields(...fields: (string | string[])[]): boolean`](#hasfieldsfields-string--string-boolean)
+    - [`@Selections(fieldSelections: string | string[] | FieldSelections[], fields?: string[], asParent: boolean = true): string[]`](#selectionsfieldselections-string--string--fieldselections-fields-string-asparent-boolean--true-string)
+
 ## Installation
 
 `@jenyus-org/nestjs-graphql-utils` can be installed from NPM by running one of the following commands:
@@ -29,6 +38,8 @@ All the utilities provided by `@jenyus-org/nestjs-graphql-utils` are exported di
 ## Decorators
 
 ### `@FieldMap(deep: boolean = true, parent: string | string[] = []): FieldMap`
+
+**New in v1.4.0**
 
 This decorator wraps the `resolveFieldMap` utility from `graphql-utils` including the direct passing of arguments fed to the decorator. It returns a raw `FieldMap` instance which takes on the form of nested objects, where the keys represent the selected fields from the `GraphQLResolveInfo`. Keys with no sub-selections are assigned an empty object as their value.
 
@@ -64,6 +75,8 @@ The returned `FieldMap` will be:
 ```
 
 ### `@Fields(deep: boolean = true, parent: string | string[] = []): string[]`
+
+**New in v1.4.0**
 
 `@Fields` is a wrapper over the `resolveFields` utility from `graphql-utils`, which itself is a light wrapper of the `resolveFieldMaps` utility that remaps the `FieldMap` return by the function with `fieldMapToDot`.
 

--- a/nestjs-graphql-utils/README.md
+++ b/nestjs-graphql-utils/README.md
@@ -34,7 +34,7 @@ This will install `@jenyus-org/nestjs-graphql-utils` and all its dependencies.
 
 ## Usage
 
-All the utilities provided by `@jenyus-org/nestjs-graphql-utils` are exported directly by the package with Typescript definitions. All the functions and decorators are described below.
+All the utilities provided by `@jenyus-org/nestjs-graphql-utils` are exported directly by the package with Typescript definitions, and are described below.
 
 ## Decorators
 

--- a/nestjs-graphql-utils/README.md
+++ b/nestjs-graphql-utils/README.md
@@ -9,6 +9,7 @@
   - [Usage](#usage)
   - [Decorators](#decorators)
     - [`@FieldMap(deep: boolean = true, parent: string | string[] = []): FieldMap`](#fieldmapdeep-boolean--true-parent-string--string---fieldmap)
+    - [`@FieldNodeAt(path: string | string[]): FieldNode | undefined`](#fieldnodeatpath-string--string-fieldnode--undefined)
     - [`@Fields(deep: boolean = true, parent: string | string[] = []): string[]`](#fieldsdeep-boolean--true-parent-string--string---string)
     - [`@HasFields(...fields: (string | string[])[]): boolean`](#hasfieldsfields-string--string-boolean)
     - [`@Selections(fieldSelections: string | string[] | FieldSelections[], fields?: string[], asParent: boolean = true): string[]`](#selectionsfieldselections-string--string--fieldselections-fields-string-asparent-boolean--true-string)
@@ -73,6 +74,12 @@ The returned `FieldMap` will be:
   }
 }
 ```
+
+### `@FieldNodeAt(path: string | string[]): FieldNode | undefined`
+
+**New in v1.5.0**
+
+`@FieldNodeAt` wraps the `getFieldNode()` utility from `graphql-utils`, which takes a path and then tries to find a field node at the specified location in the `GraphQLResolveInfo`. If none was found, `undefined` is returned instead.
 
 ### `@Fields(deep: boolean = true, parent: string | string[] = []): string[]`
 

--- a/nestjs-graphql-utils/package-lock.json
+++ b/nestjs-graphql-utils/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenyus-org/nestjs-graphql-utils",
-  "version": "1.3.0",
+  "version": "1.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -202,9 +202,9 @@
       }
     },
     "@jenyus-org/graphql-utils": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@jenyus-org/graphql-utils/-/graphql-utils-1.2.0.tgz",
-      "integrity": "sha512-wCwcWWPun3nz06REsxspdLCLtsgL+V3QJ6Da+gTYSG6yjXeIqpTHLINpAqwqTbhCaGgOjnO39wc3btxMv5GMXg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jenyus-org/graphql-utils/-/graphql-utils-1.3.0.tgz",
+      "integrity": "sha512-tkAAV0zBLxd9Jq15IBpk4I6HfgSLTVIVBbmRnWvoBxr/wZK13F1ksF9tEQpU3vsj9YGj1dWPLuXEQyqtHhdcKQ==",
       "requires": {
         "graphql": "^15.5.0"
       }

--- a/nestjs-graphql-utils/package.json
+++ b/nestjs-graphql-utils/package.json
@@ -17,7 +17,7 @@
   "private": false,
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@jenyus-org/graphql-utils": "^1.2.0",
+    "@jenyus-org/graphql-utils": "^1.3.0",
     "@nestjs/common": "^7.6.12",
     "@nestjs/core": "^7.6.12",
     "@nestjs/graphql": "^7.9.8",

--- a/nestjs-graphql-utils/src/field-node-at.decorator.test.ts
+++ b/nestjs-graphql-utils/src/field-node-at.decorator.test.ts
@@ -1,0 +1,33 @@
+import { expect } from "chai";
+import { FieldNode } from "graphql";
+import { describe } from "mocha";
+import { FieldNodeAt } from "./field-node-at.decorator";
+import { getGqlExecutionContext, getParamDecoratorFactory } from "./helpers";
+
+describe("Retrieving a field node by its specified path", () => {
+  it("Must work with multiple similar selectors", () => {
+    const ctx = getGqlExecutionContext(`{
+      user {
+        profile {
+          slug
+        }
+        profile {
+          img {
+            src
+          }
+        }
+      }
+    }`);
+
+    const fieldNodeAt = getParamDecoratorFactory(FieldNodeAt);
+
+    const fieldNode = fieldNodeAt("user.profile.img", ctx);
+
+    expect(fieldNode.kind).to.equal("Field");
+    expect(fieldNode.selectionSet.kind).to.equal("SelectionSet");
+    expect(fieldNode.selectionSet.selections[0].kind).to.equal("Field");
+    expect(
+      (fieldNode.selectionSet.selections[0] as FieldNode).name.value
+    ).to.equal("src");
+  });
+});

--- a/nestjs-graphql-utils/src/field-node-at.decorator.ts
+++ b/nestjs-graphql-utils/src/field-node-at.decorator.ts
@@ -1,0 +1,14 @@
+import { getFieldNode } from "@jenyus-org/graphql-utils";
+import { createParamDecorator, ExecutionContext } from "@nestjs/common";
+import { GqlExecutionContext } from "@nestjs/graphql";
+import { FieldNode } from "graphql";
+
+export const FieldNodeAt = (path: string | string[] = []) => {
+  return createParamDecorator<string | string[], ExecutionContext, FieldNode>(
+    (path, context) => {
+      const ctx = GqlExecutionContext.create(context);
+      const info = ctx.getInfo();
+      return getFieldNode(info, path);
+    }
+  )(path);
+};


### PR DESCRIPTION
# Overview

 - Added the `@FieldNodeAt` param decorator to wrap the `getFieldNode` utility.
 - Updated docs.

## `@FieldNodeAt()`

Given a path, will return the specified `FieldNode` from the `GraphQLResolveInfo` if any are found, otherwise returns `undefined`. Implemented with tests.