### PR TITLE
[ENHANCEMENT] @Selections() Decorator, Fix Arguments and Default Behavior, Update Docs

### DIFF
--- a/nestjs-graphql-utils/README.md
+++ b/nestjs-graphql-utils/README.md
@@ -133,6 +133,8 @@ Given the following query, `true` will be printed to the console:
 
 ### `@Selections(fieldSelections: string | string[] | FieldSelections[], fields?: string[], asParent: boolean = true): string[]`
 
+**Updated in v1.5.1**
+
 Similar to `@HasFields()`, `@Selections` acts as a layer on top of [`resolveSelections`](../graphql-utils/README.md), and additionally contains some logic to solve the most common use-case.
 
 `fieldSelections` can be the same type of argument as accepted by `resolveSelections`, and will return an array of selectors which were found in the query.
@@ -150,18 +152,25 @@ async user(
 }
 ```
 
-If the query includes the selections `posts` and `profile`, unlike passing a similar argument structure directly to `resolveSelections`, `@Selections()` will generate the following array:
-
-```ts
-["user.posts", "user.profile"]
-```
-
-**Note:** Internally `@Selections` will remap the `fields` array to the fields, prepended by the parent, similar to what is shown in the README of `graphql-utils`.
-
-To disable the behavior of remapping, and simply use the `fields` array as-is, a third argument `asParent`, which defaults to `true`, can be passed as `false`. Resulting in the following output:
+If the query includes the selections `posts` and `profile`, `@Selections()` will generate the following array:
 
 ```ts
 ["posts", "profile"]
 ```
 
-This will continue to ensure that `posts` and `profile` was found within a `user` selector, but avoid remapping their selectors.
+A final argument that may be specified, `withParent`, allows `@Selections()` to automatically remap the fields specified in the second argument and prepend them with the parent. This can be useful to do more fine-grained checks, especially when searching for subselection of relationships like so:
+
+```ts
+@Query(() => UserObject, { nullable: true })
+async user(
+  @Selections("posts", ["comments"], true) postsSelections: string[]
+) {
+  console.log(postsSelections);
+}
+```
+
+This will generate the following output, if the selection `user.posts.comments` is made in the query:
+
+```ts
+["posts.comments"]
+```

--- a/nestjs-graphql-utils/src/selections.decorator.test.ts
+++ b/nestjs-graphql-utils/src/selections.decorator.test.ts
@@ -5,6 +5,35 @@ import { getGqlExecutionContext, getParamDecoratorFactory } from "./helpers";
 import { Selections } from "./selections.decorator";
 
 describe("Resolving selectors from GraphQL query fields", () => {
+  it("Must resolve fields from the GraphQLResolveInfo", () => {
+    const ctx = getGqlExecutionContext(`{
+      user {
+        username
+        firstName
+        lastName
+      }
+    }`);
+
+    const selections = getParamDecoratorFactory(Selections);
+
+    const resolvedSelections = selections(
+      {
+        fieldSelections: "user",
+        fields: ["username", "firstName", "lastName"],
+      },
+      ctx
+    );
+
+    const expectedSelections = [
+      "username",
+      "firstName",
+      "lastName",
+    ];
+
+    expect(resolvedSelections).to.have.length(expectedSelections.length);
+    expect(resolvedSelections).to.have.members(expectedSelections);
+  });
+
   it("Must resolve fields with the parent prepended to the selector", () => {
     const ctx = getGqlExecutionContext(`{
       user {
@@ -20,6 +49,7 @@ describe("Resolving selectors from GraphQL query fields", () => {
       {
         fieldSelections: "user",
         fields: ["username", "firstName", "lastName"],
+        withParent: true,
       },
       ctx
     );

--- a/nestjs-graphql-utils/src/selections.decorator.ts
+++ b/nestjs-graphql-utils/src/selections.decorator.ts
@@ -5,7 +5,7 @@ import { FieldSelections, resolveSelections } from "@jenyus-org/graphql-utils";
 export const Selections = (
   fieldSelections: string | string[] | FieldSelections[],
   fields?: string[],
-  asParent: boolean = true
+  withParent: boolean = false
 ) => {
   if (typeof fieldSelections === "string" && !fields) {
     throw new TypeError(
@@ -17,10 +17,11 @@ export const Selections = (
     {
       fieldSelections: string | string[] | FieldSelections[];
       fields?: string[];
+      withParent: boolean;
     },
     ExecutionContext,
     string[]
-  >(({ fieldSelections, fields }, context) => {
+  >(({ fieldSelections, fields, withParent }, context) => {
     const ctx = GqlExecutionContext.create(context);
     const info = ctx.getInfo();
 
@@ -29,7 +30,7 @@ export const Selections = (
         [
           {
             field: fieldSelections,
-            selections: asParent
+            selections: withParent
               ? fields.map((f) => ({
                   field: f,
                   selector: [
@@ -45,5 +46,5 @@ export const Selections = (
     } else {
       return resolveSelections(fieldSelections, info);
     }
-  })({ fieldSelections, fields });
+  })({ fieldSelections, fields, withParent });
 };


### PR DESCRIPTION
# Overview

 - Rename `asParent` argument to `withParent`.
 - Fix passing `withParent` to decorator execution method.
 - Make default behavior `withParent = false`.
 - Update docs of `@Selections()` decorator.