### PR TITLE
[ENHANCEMENT] Add Support for Mixed Strings and FieldSelection Array in @Selections Decorator

### DIFF
--- a/nestjs-graphql-utils/src/selections.decorator.test.ts
+++ b/nestjs-graphql-utils/src/selections.decorator.test.ts
@@ -24,11 +24,36 @@ describe("Resolving selectors from GraphQL query fields", () => {
       ctx
     );
 
-    const expectedSelections = [
-      "username",
-      "firstName",
-      "lastName",
-    ];
+    const expectedSelections = ["username", "firstName", "lastName"];
+
+    expect(resolvedSelections).to.have.length(expectedSelections.length);
+    expect(resolvedSelections).to.have.members(expectedSelections);
+  });
+
+  it("Must work with mixed strings and FieldSelections", () => {
+    const ctx = getGqlExecutionContext(`{
+      user {
+        username
+        firstName
+        lastName
+      }
+    }`);
+
+    const selections = getParamDecoratorFactory(Selections);
+
+    const resolvedSelections = selections(
+      {
+        fieldSelections: "user",
+        fields: [
+          "username",
+          "firstName",
+          { field: "lastName", selector: "user.lastName" },
+        ],
+      },
+      ctx
+    );
+
+    const expectedSelections = ["username", "firstName", "user.lastName"];
 
     expect(resolvedSelections).to.have.length(expectedSelections.length);
     expect(resolvedSelections).to.have.members(expectedSelections);

--- a/nestjs-graphql-utils/src/selections.decorator.ts
+++ b/nestjs-graphql-utils/src/selections.decorator.ts
@@ -3,8 +3,8 @@ import { GqlExecutionContext } from "@nestjs/graphql";
 import { FieldSelections, resolveSelections } from "@jenyus-org/graphql-utils";
 
 export const Selections = (
-  fieldSelections: string | string[] | FieldSelections[],
-  fields?: string[],
+  fieldSelections: string | (string | FieldSelections)[],
+  fields?: (string | FieldSelections)[],
   withParent: boolean = false
 ) => {
   if (typeof fieldSelections === "string" && !fields) {
@@ -15,8 +15,8 @@ export const Selections = (
 
   return createParamDecorator<
     {
-      fieldSelections: string | string[] | FieldSelections[];
-      fields?: string[];
+      fieldSelections: string | (string | FieldSelections)[];
+      fields?: (string | FieldSelections)[];
       withParent: boolean;
     },
     ExecutionContext,
@@ -31,13 +31,17 @@ export const Selections = (
           {
             field: fieldSelections,
             selections: withParent
-              ? fields.map((f) => ({
-                  field: f,
-                  selector: [
-                    ...fieldSelections.split("."),
-                    ...f.split("."),
-                  ].join("."),
-                }))
+              ? fields.map((f) =>
+                  typeof f === "string"
+                    ? {
+                        field: f,
+                        selector: [
+                          ...fieldSelections.split("."),
+                          ...f.split("."),
+                        ].join("."),
+                      }
+                    : f
+                )
               : fields,
           },
         ],


### PR DESCRIPTION
Allows `@Selections` to be used with full coverage of the arguments accepted by `resolveSelections()` without using the raw argument.